### PR TITLE
feat: launch root quest 2 dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ All the lab lists used as the initial data for this application were curated and
 
 **Ref:** https://docs.google.com/spreadsheets/u/1/d/1dwSMIAPIam0PuRBkCiDI88pU3yzrqqHkDtBngUHNCw8/htmlview
 
-----
+---
 
 # sv
 
@@ -43,8 +43,9 @@ You can preview the production build with `npm run preview`.
 
 > To deploy your app, you may need to install an [adapter](https://svelte.dev/docs/kit/adapters) for your target environment.
 
-----
+---
+
 # Demo:
+
 https://rootquest.vercel.app/
 <img width="1494" alt="Screenshot 2568-07-07 at 11 57 58" src="https://github.com/user-attachments/assets/731f94a8-375e-4830-b769-b4f9858a4aaa" />
-

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,0 +1,58 @@
+# The OSCP Ascent – Codebase Orientation
+
+ยินดีต้อนรับสู่โปรเจกต์ **The OSCP Ascent** ซึ่งสร้างด้วย [SvelteKit](https://kit.svelte.dev/) เพื่อเป็นแอปพลิเคชันช่วยติดตามความคืบหน้าการทำแล็บสำหรับเตรียมสอบ OSCP ส่วนนี้จะสรุปโครงสร้างหลักของโค้ด สิ่งสำคัญที่ควรรู้ และแนวทางการเรียนรู้เพิ่มเติมสำหรับผู้มาใหม่
+
+## 1. โครงสร้างไฟล์หลัก
+
+```
+├── README.md              # เอกสารเบื้องต้นและลิงก์อ้างอิง
+├── package.json           # รายการสคริปต์และ dependencies ของโปรเจกต์
+├── src/
+│   ├── app.html           # โครงสร้าง HTML พื้นฐานของแอป
+│   ├── app.css            # สไตล์รวมของแอป (Tailwind utility classes ถูกใช้ในคอมโพเนนต์)
+│   ├── lib/
+│   │   ├── data/          # ไฟล์ข้อมูลเริ่มต้น (JSON ของ Hack The Box และ PG Practice)
+│   │   ├── index.js       # จุดรวมโมดูลที่เข้าผ่าน `$lib`
+│   │   └── stores.js      # Svelte store สำหรับสถานะของแล็บทั้งหมด
+│   └── routes/
+│       ├── +layout.svelte # ส่วน layout หลัก มี header/footer และปุ่ม reset localStorage
+│       ├── +page.svelte   # หน้าแดชบอร์ดหลัก จัดการรายการแล็บและโน้ต
+│       └── stats/+page.svelte # หน้ารวมสถิติการทำแล็บเสร็จตามเดือน
+└── static/                # ไฟล์สาธารณะ (หากต้องการ)
+```
+
+### รายละเอียดเพิ่มเติม
+
+- **Frontend Framework:** ใช้ SvelteKit + Vite เป็น build tool จึงมีไฟล์ `svelte.config.js`, `vite.config.js`, `eslint.config.js` และ `jsconfig.json` เพื่อกำหนดการพัฒนา
+- **Dependencies สำคัญ:** ระบุใน `package.json` เช่น `lucide-svelte` สำหรับไอคอน และ `clsx` สำหรับการจัดการ class name แบบมีเงื่อนไข
+
+## 2. การจัดการสถานะและข้อมูล
+
+- ไฟล์ `src/lib/stores.js` กำหนด writable store ชื่อ `labs` ที่อ่าน/เขียนข้อมูลผ่าน Local Storage บน browser เพื่อให้ผู้ใช้บันทึกความคืบหน้าได้ถาวร
+- เมื่อเริ่มต้น (`src/routes/+page.svelte`) แอปจะโหลดข้อมูลจาก `src/lib/data/*.json` และปรับโครงสร้างให้มีฟิลด์ที่จำเป็น เช่น `id`, `source`, `category`, `completed`, `notes`
+- ฟีเจอร์เพิ่ม/แก้ไข/ลบโน้ตถูกจัดการในหน้า `+page.svelte` ผ่าน modal และอัปเดต `labs` store ให้เป็นไปตามสคีมาที่กำหนด
+
+## 3. หน้า UI หลัก
+
+- `+layout.svelte` ให้กรอบ UI รวม พร้อมปุ่ม **Reset Data** ที่ลบคีย์ `my-advanced-labs` ใน Local Storage และรีเฟรชหน้า
+- `+page.svelte` เป็นแดชบอร์ดที่เลือกหมวดหมู่ของแล็บ แสดงการ์ดของแต่ละแล็บ ปุ่มเปิดลิงก์ Hack The Box, ปุ่มจดโน้ต และ checkbox "Owned" เพื่ออัปเดตสถานะ
+- `stats/+page.svelte` แปลงข้อมูลจาก store ให้เป็นสถิติรายเดือน โดยอาศัย timestamp จาก `completedAt`
+
+## 4. สิ่งสำคัญที่ควรรู้สำหรับผู้เริ่มต้น
+
+1. **Local Storage เป็นแหล่งข้อมูลหลักขณะรัน** – ตรวจสอบ logic ใน `stores.js` หากต้องเปลี่ยนรูปแบบข้อมูลหรือย้ายไป backend จริง
+2. **สคีมาของ Lab Object** – ทุกแล็บควรมีฟิลด์ `{ id, name, difficulty, os, source, category, completed, completedAt, notes[] }` เพื่อให้ฟีเจอร์ทั้งหมดทำงานถูกต้อง
+3. **การใช้ Svelte reactive statements** (`$:`) – ใช้คำนวณค่าที่ต้องอัปเดตอัตโนมัติ เช่น รายการแล็บตามหมวดหมู่และสถิติ OS
+4. **Component Styling** – ใช้ Tailwind utility classes โดยกำหนด global ที่ `app.css` และแทรกตรงคอมโพเนนต์
+
+## 5. แนวทางการเรียนรู้ต่อ
+
+- **พื้นฐาน Svelte/SvelteKit:** ทำความเข้าใจไฟล์ routing (`+page.svelte`, `+layout.svelte`), stores, และการ binding ต่าง ๆ จาก [เอกสาร Svelte](https://svelte.dev/docs) และ [SvelteKit](https://kit.svelte.dev/docs)
+- **การจัดการสถานะขั้นสูง:** ศึกษา Svelte stores เพิ่มเติม (derived store, readable) หากต้องการคำนวณข้อมูลซับซ้อนขึ้น หรือเชื่อมต่อ API ภายนอก
+- **การเพิ่มฟีเจอร์:** ตัวอย่างเช่น ระบบกรอง/ค้นหาแล็บ, การซิงก์ข้อมูลกับ backend, หรือการแสดงกราฟในหน้า stats (อาจใช้ไลบรารีอย่าง Chart.js)
+- **การทดสอบและคุณภาพโค้ด:** ตั้งค่า unit test (เช่น Vitest) และใช้ ESLint/Prettier ตามที่ระบุในโปรเจกต์เพื่อรักษามาตรฐานโค้ด
+- **Deployment:** ศึกษา adapter ของ SvelteKit เพื่อดีพลอยขึ้น Vercel, Netlify หรือโฮสต์อื่น ๆ พร้อมตั้งค่า environment variables หากเชื่อมบริการภายนอก
+
+---
+
+หากมีคำถามเพิ่มเติมหรืออยากทราบส่วนใดละเอียดขึ้น สามารถเปิดไฟล์ในไดเร็กทอรี `src/` ตามที่ระบุด้านบนเพื่อสำรวจโค้ดจริงประกอบได้เลยครับ

--- a/src/app.css
+++ b/src/app.css
@@ -1,1 +1,19 @@
 @import 'tailwindcss';
+
+@layer components {
+	.note-screenshot {
+		@apply my-4 overflow-hidden rounded-2xl border border-slate-200 bg-slate-100 dark:border-slate-800 dark:bg-slate-900/50;
+	}
+
+	.note-screenshot img {
+		@apply h-auto w-full object-contain;
+	}
+
+	.note-code {
+		@apply rounded-xl bg-slate-900 p-4 text-sm whitespace-pre-wrap text-slate-100 shadow-inner;
+	}
+
+	.note-list {
+		@apply list-disc space-y-1 pl-6 text-sm;
+	}
+}

--- a/src/lib/data/htb_labs.json
+++ b/src/lib/data/htb_labs.json
@@ -1,96 +1,426 @@
 {
-  "listName": "Hack The Box",
-  "categories": [
-    {
-      "name": "Linux Boxes",
-      "labs": [
-        { "name": "Busqueda", "os": "Linux", "difficulty": "Hard", "avatar": "https://labs.hackthebox.com/storage/avatars/a6942ab57b6a79f71240420442027334.png" },
-        { "name": "UpDown", "os": "Linux", "difficulty": "Easy", "avatar": "https://labs.hackthebox.com/storage/avatars/d7a56d5f25100d0a918b90de80122f82.png" },
-        { "name": "Sau", "os": "Linux", "difficulty": "Easy", "avatar": "https://labs.hackthebox.com/storage/avatars/1ea2980b9dc2d11cf6a3f82f10ba8702.png" },
-        { "name": "Broker", "os": "Windows", "difficulty": "Medium", "avatar": "https://labs.hackthebox.com/storage/avatars/a725533911ba94a880899fbf900d988c.png" },
-        { "name": "Intentions", "os": "Windows", "difficulty": "Hard", "avatar": "https://labs.hackthebox.com/storage/avatars/f51a05c5eceb08937686766c1b7de0cc.png" },
-        { "name": "Soccer", "os": "Linux", "difficulty": "Medium", "avatar": "https://labs.hackthebox.com/storage/avatars/ca7f69a02eebf53deb3cd1611dd3f55e.png" },
-        { "name": "Keeper", "os": "Windows", "difficulty": "Medium", "avatar": "https://labs.hackthebox.com/storage/avatars/b56a5742b99e2568fa167765b1323370.png" },
-        { "name": "Monitored", "os": "Linux", "difficulty": "Medium", "avatar": "https://labs.hackthebox.com/storage/avatars/d4988810825d26acb2e84ca0ac9feaf4.png" },
-        { "name": "BoardLight", "os": "Linux", "difficulty": "Intermediate", "avatar": "https://labs.hackthebox.com/storage/avatars/7768afed979c9abe917b0c20df49ceb8.png" },
-        { "name": "Networked", "os": "Windows", "difficulty": "Medium", "avatar": "https://labs.hackthebox.com/storage/avatars/0b286019523dcd78cf03d3a3472a3792.png" },
-        { "name": "CozyHosting", "os": "Linux", "difficulty": "Medium", "avatar": "https://labs.hackthebox.com/storage/avatars/eaed7cd01e84ef5c6ec7d949d1d61110.png" },
-        { "name": "Editorial", "os": "Windows", "difficulty": "Easy", "avatar": "https://labs.hackthebox.com/storage/avatars/a466db5ce4f7aaea98f588d1cb71a0aa.png" },
-        { "name": "Magic", "os": "Windows", "difficulty": "Easy", "avatar": "https://labs.hackthebox.com/storage/avatars/73eebbbdfbbfd46258ea2ae7e52d9479.png" },
-        { "name": "Pandora", "os": "Windows", "difficulty": "Medium", "avatar": "https://labs.hackthebox.com/storage/avatars/6ac0e76002774bbfac92b0dbc86cb6af.png" },
-        { "name": "Builder", "os": "Linux", "difficulty": "Easy", "avatar": "https://labs.hackthebox.com/storage/avatars/a0f6d6a08e0806448341587cd59450a6.png" },
-        { "name": "LinkVortex", "os": "Linux", "difficulty": "Intermediate", "avatar": "https://labs.hackthebox.com/storage/avatars/97f12db8fafed028448e29e30be7efac.png" },
-        { "name": "Dog", "os": "Linux", "difficulty": "Easy", "avatar": "https://labs.hackthebox.com/storage/avatars/426830ea2ae4f05f7892ad89195f8276.png" },
-        { "name": "Markup", "os": "Linux", "difficulty": "Easy", "avatar": "https://labs.hackthebox.com/storage/avatars/619fa91801ba0956c435db03ab267118.png" },
-        { "name": "Usage", "os": "Linux", "difficulty": "Easy", "avatar": "https://labs.hackthebox.com/storage/avatars/23e804513a47e8f20bc865d0419946e1.png" },
-        { "name": "Artificial", "os": "Linux", "difficulty": "Easy", "avatar": "https://labs.hackthebox.com/storage/avatars/e6633d6c2b1d824c3756eb21aeed7590.png" },
-        { "name": "Nocturnal", "os": "Linux", "difficulty": "Easy", "avatar": "https://labs.hackthebox.com/storage/avatars/f6a56cec6e9826b4ed124fb4155abc66.png" },
-        { "name": "Titanic", "os": "Linux", "difficulty": "Easy", "avatar": "https://labs.hackthebox.com/storage/avatars/eb5942ec56dd9b6feb06dcf8af8aefc6.png" },
-        { "name": "Underpass", "os": "Linux", "difficulty": "Easy", "avatar": "https://labs.hackthebox.com/storage/avatars/456a4d2e52f182847fb0a2dba0420a44.png" }
-      ]
-    },
-    {
-      "name": "Windows Boxes",
-      "labs": [
-        { "name": "Help", "os": "Windows", "difficulty": "Easy", "avatar": "https://labs.hackthebox.com/storage/avatars/2f6225d90a3caf56699c3d93e8779d6b.png" },
-        { "name": "Escape", "os": "Windows", "difficulty": "Hard", "avatar": "https://labs.hackthebox.com/storage/avatars/80936664b3da83a92b28602e79e47d79.png" },
-        { "name": "Servmon", "os": "Windows", "difficulty": "Easy", "avatar": "https://labs.hackthebox.com/storage/avatars/2bc1a8dc04b09b8ac2db694f25ccf051.png" },
-        { "name": "Support", "os": "Windows", "difficulty": "Medium", "avatar": "https://labs.hackthebox.com/storage/avatars/833a3b1f7f96b5708d19b6de084c3201.png" },
-        { "name": "StreamIO", "os": "Windows", "difficulty": "Medium", "avatar": "https://labs.hackthebox.com/storage/avatars/21240942d301a96e80574353a96b9003.png" },
-        { "name": "Blackfield", "os": "Windows", "difficulty": "Hard", "avatar": "https://labs.hackthebox.com/storage/avatars/7c69c876f496cd729a077277757d219d.png" },
-        { "name": "Intelligence", "os": "Windows", "difficulty": "Medium", "avatar": "https://labs.hackthebox.com/storage/avatars/78c5d8511bae13864c72ba8df1329e8d.png" },
-        { "name": "Jeeves", "os": "Windows", "difficulty": "Easy", "avatar": "https://labs.hackthebox.com/storage/avatars/709059a710d3d6ff1ba32bf0729ecbb8.png" },
-        { "name": "Manager", "os": "Windows", "difficulty": "Medium", "avatar": "https://labs.hackthebox.com/storage/avatars/5ca8f0c721a9eca6f1aeb9ff4b4bac60.png" },
-        { "name": "Access", "os": "Windows", "difficulty": "Easy", "avatar": "https://labs.hackthebox.com/storage/avatars/adef7ad3d015a1fbc5235d5a201ca7d1.png" },
-        { "name": "Aero", "os": "Windows", "difficulty": "Medium", "avatar": "https://labs.hackthebox.com/storage/avatars/d7402e63f4067df1dbbe7b143c90d61d.png" },
-        { "name": "Mailing", "os": "Windows", "difficulty": "Hard", "avatar": "https://labs.hackthebox.com/storage/avatars/cedb2f991409f9f39b55b04513f6b102.png" },
-        { "name": "Administrator", "os": "Windows", "difficulty": "Hard", "avatar": "https://labs.hackthebox.com/storage/avatars/9d232b1558b7543c7cb85f2774687363.png" },
-        { "name": "Certified", "os": "Windows", "difficulty": "Medium", "avatar": "https://labs.hackthebox.com/storage/avatars/28b71ec11bb839b5b58bdfc555006816.png" }
-      ]
-    },
-    {
-      "name": "Windows Active Directory Boxes",
-      "labs": [
-        { "name": "Active", "os": "Active Directory", "difficulty": "Easy", "avatar": "https://labs.hackthebox.com/storage/avatars/5837ac5e28291146a9f2a8a015540c28.png" },
-        { "name": "Forest", "os": "Active Directory", "difficulty": "Easy", "avatar": "https://labs.hackthebox.com/storage/avatars/7dedecb452597150647e73c2dd6c24c7.png" },
-        { "name": "Sauna", "os": "Active Directory", "difficulty": "Medium", "avatar": "https://labs.hackthebox.com/storage/avatars/f31d5d0264fadc267e7f38a9d7729d14.png" },
-        { "name": "Monteverde", "os": "Active Directory", "difficulty": "Medium", "avatar": "https://labs.hackthebox.com/storage/avatars/00ceebe5dbef1106ce4390365cd787b4.png" },
-        { "name": "Timelapse", "os": "Active Directory", "difficulty": "Medium", "avatar": "https://labs.hackthebox.com/storage/avatars/bae443f73a706fc8eebc6fb740128295.png" },
-        { "name": "Return", "os": "Active Directory", "difficulty": "Easy", "avatar": "https://labs.hackthebox.com/storage/avatars/defa149ea7e259a4709a03a5825e970d.png" },
-        { "name": "Cascade", "os": "Active Directory", "difficulty": "Medium", "avatar": "https://labs.hackthebox.com/storage/avatars/64fef851357b8de1c4834093bf3426f2.png" },
-        { "name": "Flight", "os": "Active Directory", "difficulty": "Medium", "avatar": "https://labs.hackthebox.com/storage/avatars/a7af9035e5089332dfbfeb328d663f3e.png" },
-        { "name": "Cicada", "os": "Active Directory", "difficulty": "Hard", "avatar": "https://labs.hackthebox.com/storage/avatars/79616a32a057e5e672dadb51bb96dd04.png" },
-        { "name": "TheFrizz", "os": "Active Directory", "difficulty": "Medium", "avatar": "https://labs.hackthebox.com/storage/avatars/c91ef1b641cf88156c7a9d3793d54216.png" },
-        { "name": "Puppy", "os": "Active Directory", "difficulty": "Medium", "avatar": "https://labs.hackthebox.com/storage/avatars/6a127b39657062e42c1a8dfdcd23475d.png" },
-        { "name": "TombWatcher", "os": "Active Directory", "difficulty": "Medium", "avatar": "https://labs.hackthebox.com/storage/avatars/59c74a969b4fec16cd8072d253ca9917.png" }
-      ]
-    },
-    {
-      "name": "Post OSCP Section. Challenging yourself",
-      "labs": [
-        { "name": "Mentor", "os": "Linux", "difficulty": "Medium", "avatar": "https://labs.hackthebox.com/storage/avatars/15857f8d886a3d044e3a4e08acd81bcd.png" },
-        { "name": "Absolute", "os": "Windows", "difficulty": "Hard", "avatar": "https://labs.hackthebox.com/storage/avatars/d5dbb09284d3265d91f50eb4ad32fee2.png" },
-        { "name": "Outdated", "os": "Windows", "difficulty": "Medium", "avatar": "https://labs.hackthebox.com/storage/avatars/3494a3a243d6f971c5122ad81cb2254e.png" },
-        { "name": "Atom", "os": "Windows", "difficulty": "Medium", "avatar": "https://labs.hackthebox.com/storage/avatars/27ea1e1be5e83989ad5b6361773f4eaa.png" },
-        { "name": "APT", "os": "Windows", "difficulty": "Hard", "avatar": "https://labs.hackthebox.com/storage/avatars/bbf0ca0388599663e0d8b6955a0760d3.png" },
-        { "name": "Cerberus", "os": "Windows/Linux", "difficulty": "Hard", "avatar": "https://labs.hackthebox.com/storage/avatars/0ec0d1f3e6e5f8602892e310c28079e6.png" },
-        { "name": "Multimaster", "os": "Windows", "difficulty": "Hard", "avatar": "https://labs.hackthebox.com/storage/avatars/f382c5c7b60b502c9f12606b5545e980.png" },
-        { "name": "Cereal", "os": "Linux", "difficulty": "Hard", "avatar": "https://labs.hackthebox.com/storage/avatars/6a493b8c3624a5b4a7f6a289cd099c34.png" },
-        { "name": "Quick", "os": "Linux", "difficulty": "Hard", "avatar": "https://labs.hackthebox.com/storage/avatars/c2096057971181c8d36031fb6f1f7a8a.png" },
-        { "name": "Authority", "os": "Windows", "difficulty": "Medium", "avatar": "https://labs.hackthebox.com/storage/avatars/e6257bbacb2ddd56f5703bb61eadd8cb.png" },
-        { "name": "Clicker", "os": "Linux", "difficulty": "Medium", "avatar": "https://labs.hackthebox.com/storage/avatars/5a89d213ede5af4b4f94035fd059f976.png" },
-        { "name": "Rebound", "os": "Windows", "difficulty": "Hard", "avatar": "https://labs.hackthebox.com/storage/avatars/2ad5dcb2fb97e40f5e88a0d6fc569bdd.png" },
-        { "name": "Vintage", "os": "Windows", "difficulty": "Hard", "avatar": "https://labs.hackthebox.com/storage/avatars/4eae732c7af0ce1b443d009637167610.png" }
-      ]
-    },
-    {
-      "name": "ProLabs",
-      "labs": [
-        { "name": "Dante", "os": "Linux", "difficulty": "Hard", "avatar": "https://app.hackthebox.com/images/icons/ic-prolabs/ic-dante-overview.svg" },
-        { "name": "RastaLabs", "os": "Linux", "difficulty": "Hard", "avatar": "https://app.hackthebox.com/images/icons/ic-prolabs/ic-rastalabs-overview.svg" },
-        { "name": "Zephyr", "os": "Windows", "difficulty": "Hard", "avatar": "https://app.hackthebox.com/images/icons/ic-prolabs/ic-zephyr-overview.svg" },
-        { "name": "Alchemy", "os": "Windows", "difficulty": "Hard", "avatar": "https://app.hackthebox.com/images/icons/ic-prolabs/ic-alchemy-overview.svg" }
-      ]
-    }
-  ]
+	"listName": "Hack The Box",
+	"categories": [
+		{
+			"name": "Linux Boxes",
+			"labs": [
+				{
+					"name": "Busqueda",
+					"os": "Linux",
+					"difficulty": "Hard",
+					"avatar": "https://labs.hackthebox.com/storage/avatars/a6942ab57b6a79f71240420442027334.png"
+				},
+				{
+					"name": "UpDown",
+					"os": "Linux",
+					"difficulty": "Easy",
+					"avatar": "https://labs.hackthebox.com/storage/avatars/d7a56d5f25100d0a918b90de80122f82.png"
+				},
+				{
+					"name": "Sau",
+					"os": "Linux",
+					"difficulty": "Easy",
+					"avatar": "https://labs.hackthebox.com/storage/avatars/1ea2980b9dc2d11cf6a3f82f10ba8702.png"
+				},
+				{
+					"name": "Broker",
+					"os": "Windows",
+					"difficulty": "Medium",
+					"avatar": "https://labs.hackthebox.com/storage/avatars/a725533911ba94a880899fbf900d988c.png"
+				},
+				{
+					"name": "Intentions",
+					"os": "Windows",
+					"difficulty": "Hard",
+					"avatar": "https://labs.hackthebox.com/storage/avatars/f51a05c5eceb08937686766c1b7de0cc.png"
+				},
+				{
+					"name": "Soccer",
+					"os": "Linux",
+					"difficulty": "Medium",
+					"avatar": "https://labs.hackthebox.com/storage/avatars/ca7f69a02eebf53deb3cd1611dd3f55e.png"
+				},
+				{
+					"name": "Keeper",
+					"os": "Windows",
+					"difficulty": "Medium",
+					"avatar": "https://labs.hackthebox.com/storage/avatars/b56a5742b99e2568fa167765b1323370.png"
+				},
+				{
+					"name": "Monitored",
+					"os": "Linux",
+					"difficulty": "Medium",
+					"avatar": "https://labs.hackthebox.com/storage/avatars/d4988810825d26acb2e84ca0ac9feaf4.png"
+				},
+				{
+					"name": "BoardLight",
+					"os": "Linux",
+					"difficulty": "Intermediate",
+					"avatar": "https://labs.hackthebox.com/storage/avatars/7768afed979c9abe917b0c20df49ceb8.png"
+				},
+				{
+					"name": "Networked",
+					"os": "Windows",
+					"difficulty": "Medium",
+					"avatar": "https://labs.hackthebox.com/storage/avatars/0b286019523dcd78cf03d3a3472a3792.png"
+				},
+				{
+					"name": "CozyHosting",
+					"os": "Linux",
+					"difficulty": "Medium",
+					"avatar": "https://labs.hackthebox.com/storage/avatars/eaed7cd01e84ef5c6ec7d949d1d61110.png"
+				},
+				{
+					"name": "Editorial",
+					"os": "Windows",
+					"difficulty": "Easy",
+					"avatar": "https://labs.hackthebox.com/storage/avatars/a466db5ce4f7aaea98f588d1cb71a0aa.png"
+				},
+				{
+					"name": "Magic",
+					"os": "Windows",
+					"difficulty": "Easy",
+					"avatar": "https://labs.hackthebox.com/storage/avatars/73eebbbdfbbfd46258ea2ae7e52d9479.png"
+				},
+				{
+					"name": "Pandora",
+					"os": "Windows",
+					"difficulty": "Medium",
+					"avatar": "https://labs.hackthebox.com/storage/avatars/6ac0e76002774bbfac92b0dbc86cb6af.png"
+				},
+				{
+					"name": "Builder",
+					"os": "Linux",
+					"difficulty": "Easy",
+					"avatar": "https://labs.hackthebox.com/storage/avatars/a0f6d6a08e0806448341587cd59450a6.png"
+				},
+				{
+					"name": "LinkVortex",
+					"os": "Linux",
+					"difficulty": "Intermediate",
+					"avatar": "https://labs.hackthebox.com/storage/avatars/97f12db8fafed028448e29e30be7efac.png"
+				},
+				{
+					"name": "Dog",
+					"os": "Linux",
+					"difficulty": "Easy",
+					"avatar": "https://labs.hackthebox.com/storage/avatars/426830ea2ae4f05f7892ad89195f8276.png"
+				},
+				{
+					"name": "Markup",
+					"os": "Linux",
+					"difficulty": "Easy",
+					"avatar": "https://labs.hackthebox.com/storage/avatars/619fa91801ba0956c435db03ab267118.png"
+				},
+				{
+					"name": "Usage",
+					"os": "Linux",
+					"difficulty": "Easy",
+					"avatar": "https://labs.hackthebox.com/storage/avatars/23e804513a47e8f20bc865d0419946e1.png"
+				},
+				{
+					"name": "Artificial",
+					"os": "Linux",
+					"difficulty": "Easy",
+					"avatar": "https://labs.hackthebox.com/storage/avatars/e6633d6c2b1d824c3756eb21aeed7590.png"
+				},
+				{
+					"name": "Nocturnal",
+					"os": "Linux",
+					"difficulty": "Easy",
+					"avatar": "https://labs.hackthebox.com/storage/avatars/f6a56cec6e9826b4ed124fb4155abc66.png"
+				},
+				{
+					"name": "Titanic",
+					"os": "Linux",
+					"difficulty": "Easy",
+					"avatar": "https://labs.hackthebox.com/storage/avatars/eb5942ec56dd9b6feb06dcf8af8aefc6.png"
+				},
+				{
+					"name": "Underpass",
+					"os": "Linux",
+					"difficulty": "Easy",
+					"avatar": "https://labs.hackthebox.com/storage/avatars/456a4d2e52f182847fb0a2dba0420a44.png"
+				}
+			]
+		},
+		{
+			"name": "Windows Boxes",
+			"labs": [
+				{
+					"name": "Help",
+					"os": "Windows",
+					"difficulty": "Easy",
+					"avatar": "https://labs.hackthebox.com/storage/avatars/2f6225d90a3caf56699c3d93e8779d6b.png"
+				},
+				{
+					"name": "Escape",
+					"os": "Windows",
+					"difficulty": "Hard",
+					"avatar": "https://labs.hackthebox.com/storage/avatars/80936664b3da83a92b28602e79e47d79.png"
+				},
+				{
+					"name": "Servmon",
+					"os": "Windows",
+					"difficulty": "Easy",
+					"avatar": "https://labs.hackthebox.com/storage/avatars/2bc1a8dc04b09b8ac2db694f25ccf051.png"
+				},
+				{
+					"name": "Support",
+					"os": "Windows",
+					"difficulty": "Medium",
+					"avatar": "https://labs.hackthebox.com/storage/avatars/833a3b1f7f96b5708d19b6de084c3201.png"
+				},
+				{
+					"name": "StreamIO",
+					"os": "Windows",
+					"difficulty": "Medium",
+					"avatar": "https://labs.hackthebox.com/storage/avatars/21240942d301a96e80574353a96b9003.png"
+				},
+				{
+					"name": "Blackfield",
+					"os": "Windows",
+					"difficulty": "Hard",
+					"avatar": "https://labs.hackthebox.com/storage/avatars/7c69c876f496cd729a077277757d219d.png"
+				},
+				{
+					"name": "Intelligence",
+					"os": "Windows",
+					"difficulty": "Medium",
+					"avatar": "https://labs.hackthebox.com/storage/avatars/78c5d8511bae13864c72ba8df1329e8d.png"
+				},
+				{
+					"name": "Jeeves",
+					"os": "Windows",
+					"difficulty": "Easy",
+					"avatar": "https://labs.hackthebox.com/storage/avatars/709059a710d3d6ff1ba32bf0729ecbb8.png"
+				},
+				{
+					"name": "Manager",
+					"os": "Windows",
+					"difficulty": "Medium",
+					"avatar": "https://labs.hackthebox.com/storage/avatars/5ca8f0c721a9eca6f1aeb9ff4b4bac60.png"
+				},
+				{
+					"name": "Access",
+					"os": "Windows",
+					"difficulty": "Easy",
+					"avatar": "https://labs.hackthebox.com/storage/avatars/adef7ad3d015a1fbc5235d5a201ca7d1.png"
+				},
+				{
+					"name": "Aero",
+					"os": "Windows",
+					"difficulty": "Medium",
+					"avatar": "https://labs.hackthebox.com/storage/avatars/d7402e63f4067df1dbbe7b143c90d61d.png"
+				},
+				{
+					"name": "Mailing",
+					"os": "Windows",
+					"difficulty": "Hard",
+					"avatar": "https://labs.hackthebox.com/storage/avatars/cedb2f991409f9f39b55b04513f6b102.png"
+				},
+				{
+					"name": "Administrator",
+					"os": "Windows",
+					"difficulty": "Hard",
+					"avatar": "https://labs.hackthebox.com/storage/avatars/9d232b1558b7543c7cb85f2774687363.png"
+				},
+				{
+					"name": "Certified",
+					"os": "Windows",
+					"difficulty": "Medium",
+					"avatar": "https://labs.hackthebox.com/storage/avatars/28b71ec11bb839b5b58bdfc555006816.png"
+				}
+			]
+		},
+		{
+			"name": "Windows Active Directory Boxes",
+			"labs": [
+				{
+					"name": "Active",
+					"os": "Active Directory",
+					"difficulty": "Easy",
+					"avatar": "https://labs.hackthebox.com/storage/avatars/5837ac5e28291146a9f2a8a015540c28.png"
+				},
+				{
+					"name": "Forest",
+					"os": "Active Directory",
+					"difficulty": "Easy",
+					"avatar": "https://labs.hackthebox.com/storage/avatars/7dedecb452597150647e73c2dd6c24c7.png"
+				},
+				{
+					"name": "Sauna",
+					"os": "Active Directory",
+					"difficulty": "Medium",
+					"avatar": "https://labs.hackthebox.com/storage/avatars/f31d5d0264fadc267e7f38a9d7729d14.png"
+				},
+				{
+					"name": "Monteverde",
+					"os": "Active Directory",
+					"difficulty": "Medium",
+					"avatar": "https://labs.hackthebox.com/storage/avatars/00ceebe5dbef1106ce4390365cd787b4.png"
+				},
+				{
+					"name": "Timelapse",
+					"os": "Active Directory",
+					"difficulty": "Medium",
+					"avatar": "https://labs.hackthebox.com/storage/avatars/bae443f73a706fc8eebc6fb740128295.png"
+				},
+				{
+					"name": "Return",
+					"os": "Active Directory",
+					"difficulty": "Easy",
+					"avatar": "https://labs.hackthebox.com/storage/avatars/defa149ea7e259a4709a03a5825e970d.png"
+				},
+				{
+					"name": "Cascade",
+					"os": "Active Directory",
+					"difficulty": "Medium",
+					"avatar": "https://labs.hackthebox.com/storage/avatars/64fef851357b8de1c4834093bf3426f2.png"
+				},
+				{
+					"name": "Flight",
+					"os": "Active Directory",
+					"difficulty": "Medium",
+					"avatar": "https://labs.hackthebox.com/storage/avatars/a7af9035e5089332dfbfeb328d663f3e.png"
+				},
+				{
+					"name": "Cicada",
+					"os": "Active Directory",
+					"difficulty": "Hard",
+					"avatar": "https://labs.hackthebox.com/storage/avatars/79616a32a057e5e672dadb51bb96dd04.png"
+				},
+				{
+					"name": "TheFrizz",
+					"os": "Active Directory",
+					"difficulty": "Medium",
+					"avatar": "https://labs.hackthebox.com/storage/avatars/c91ef1b641cf88156c7a9d3793d54216.png"
+				},
+				{
+					"name": "Puppy",
+					"os": "Active Directory",
+					"difficulty": "Medium",
+					"avatar": "https://labs.hackthebox.com/storage/avatars/6a127b39657062e42c1a8dfdcd23475d.png"
+				},
+				{
+					"name": "TombWatcher",
+					"os": "Active Directory",
+					"difficulty": "Medium",
+					"avatar": "https://labs.hackthebox.com/storage/avatars/59c74a969b4fec16cd8072d253ca9917.png"
+				}
+			]
+		},
+		{
+			"name": "Post OSCP Section. Challenging yourself",
+			"labs": [
+				{
+					"name": "Mentor",
+					"os": "Linux",
+					"difficulty": "Medium",
+					"avatar": "https://labs.hackthebox.com/storage/avatars/15857f8d886a3d044e3a4e08acd81bcd.png"
+				},
+				{
+					"name": "Absolute",
+					"os": "Windows",
+					"difficulty": "Hard",
+					"avatar": "https://labs.hackthebox.com/storage/avatars/d5dbb09284d3265d91f50eb4ad32fee2.png"
+				},
+				{
+					"name": "Outdated",
+					"os": "Windows",
+					"difficulty": "Medium",
+					"avatar": "https://labs.hackthebox.com/storage/avatars/3494a3a243d6f971c5122ad81cb2254e.png"
+				},
+				{
+					"name": "Atom",
+					"os": "Windows",
+					"difficulty": "Medium",
+					"avatar": "https://labs.hackthebox.com/storage/avatars/27ea1e1be5e83989ad5b6361773f4eaa.png"
+				},
+				{
+					"name": "APT",
+					"os": "Windows",
+					"difficulty": "Hard",
+					"avatar": "https://labs.hackthebox.com/storage/avatars/bbf0ca0388599663e0d8b6955a0760d3.png"
+				},
+				{
+					"name": "Cerberus",
+					"os": "Windows/Linux",
+					"difficulty": "Hard",
+					"avatar": "https://labs.hackthebox.com/storage/avatars/0ec0d1f3e6e5f8602892e310c28079e6.png"
+				},
+				{
+					"name": "Multimaster",
+					"os": "Windows",
+					"difficulty": "Hard",
+					"avatar": "https://labs.hackthebox.com/storage/avatars/f382c5c7b60b502c9f12606b5545e980.png"
+				},
+				{
+					"name": "Cereal",
+					"os": "Linux",
+					"difficulty": "Hard",
+					"avatar": "https://labs.hackthebox.com/storage/avatars/6a493b8c3624a5b4a7f6a289cd099c34.png"
+				},
+				{
+					"name": "Quick",
+					"os": "Linux",
+					"difficulty": "Hard",
+					"avatar": "https://labs.hackthebox.com/storage/avatars/c2096057971181c8d36031fb6f1f7a8a.png"
+				},
+				{
+					"name": "Authority",
+					"os": "Windows",
+					"difficulty": "Medium",
+					"avatar": "https://labs.hackthebox.com/storage/avatars/e6257bbacb2ddd56f5703bb61eadd8cb.png"
+				},
+				{
+					"name": "Clicker",
+					"os": "Linux",
+					"difficulty": "Medium",
+					"avatar": "https://labs.hackthebox.com/storage/avatars/5a89d213ede5af4b4f94035fd059f976.png"
+				},
+				{
+					"name": "Rebound",
+					"os": "Windows",
+					"difficulty": "Hard",
+					"avatar": "https://labs.hackthebox.com/storage/avatars/2ad5dcb2fb97e40f5e88a0d6fc569bdd.png"
+				},
+				{
+					"name": "Vintage",
+					"os": "Windows",
+					"difficulty": "Hard",
+					"avatar": "https://labs.hackthebox.com/storage/avatars/4eae732c7af0ce1b443d009637167610.png"
+				}
+			]
+		},
+		{
+			"name": "ProLabs",
+			"labs": [
+				{
+					"name": "Dante",
+					"os": "Linux",
+					"difficulty": "Hard",
+					"avatar": "https://app.hackthebox.com/images/icons/ic-prolabs/ic-dante-overview.svg"
+				},
+				{
+					"name": "RastaLabs",
+					"os": "Linux",
+					"difficulty": "Hard",
+					"avatar": "https://app.hackthebox.com/images/icons/ic-prolabs/ic-rastalabs-overview.svg"
+				},
+				{
+					"name": "Zephyr",
+					"os": "Windows",
+					"difficulty": "Hard",
+					"avatar": "https://app.hackthebox.com/images/icons/ic-prolabs/ic-zephyr-overview.svg"
+				},
+				{
+					"name": "Alchemy",
+					"os": "Windows",
+					"difficulty": "Hard",
+					"avatar": "https://app.hackthebox.com/images/icons/ic-prolabs/ic-alchemy-overview.svg"
+				}
+			]
+		}
+	]
 }

--- a/src/lib/data/oscp_labs.json
+++ b/src/lib/data/oscp_labs.json
@@ -1,0 +1,61 @@
+{
+	"listName": "OSCP Labs",
+	"description": "Core PWK, ProLabs, and post-exam lab targets for Root Quest 2.0",
+	"categories": [
+		{
+			"name": "PWK Core",
+			"labs": [
+				{
+					"name": "Alpha",
+					"difficulty": "Easy",
+					"os": "Linux",
+					"services": ["http", "ssh"],
+					"cves": ["CVE-2019-11043"],
+					"tags": ["web", "buffer overflow"]
+				},
+				{
+					"name": "Beta",
+					"difficulty": "Medium",
+					"os": "Windows",
+					"services": ["smb", "rdp"],
+					"cves": [],
+					"tags": ["active directory", "kerberoasting"]
+				}
+			]
+		},
+		{
+			"name": "ProLabs",
+			"labs": [
+				{
+					"name": "Rastamouse",
+					"difficulty": "Hard",
+					"os": "Active Directory",
+					"services": ["ad", "ldap"],
+					"cves": ["CVE-2021-42278"],
+					"tags": ["bloodhound", "ad cs"]
+				},
+				{
+					"name": "Medtech",
+					"difficulty": "Hard",
+					"os": "Windows",
+					"services": ["web", "winrm"],
+					"cves": [],
+					"tags": ["prolab", "pivoting"]
+				}
+			]
+		},
+		{
+			"name": "Post-OSCP",
+			"labs": [
+				{
+					"name": "Awakened",
+					"difficulty": "Intermediate",
+					"os": "Linux",
+					"services": ["http", "mysql"],
+					"cves": ["CVE-2020-1472"],
+					"tags": ["research", "writeup"]
+				}
+			]
+		}
+	]
+}

--- a/src/lib/data/pg_practice_labs.json
+++ b/src/lib/data/pg_practice_labs.json
@@ -1,87 +1,87 @@
 {
-  "listName": "Proving Grounds Practice",
-  "categories": [
-    {
-      "name": "Linux Boxes",
-      "labs": [
-        { "name": "Twiggy", "os": "Linux", "difficulty": "Intermediate", "avatar": "" },
-        { "name": "Exfiltrated", "os": "Linux", "difficulty": "Intermediate", "avatar": "" },
-        { "name": "Pelican", "os": "Linux", "difficulty": "Intermediate", "avatar": "" },
-        { "name": "Astronaut", "os": "Linux", "difficulty": "Intermediate", "avatar": "" },
-        { "name": "Blackgate", "os": "Linux", "difficulty": "Intermediate", "avatar": "" },
-        { "name": "Boolean", "os": "Linux", "difficulty": "Intermediate", "avatar": "" },
-        { "name": "Clue", "os": "Linux", "difficulty": "Intermediate", "avatar": "" },
-        { "name": "Cockpit", "os": "Linux", "difficulty": "Intermediate", "avatar": "" },
-        { "name": "Codo", "os": "Linux", "difficulty": "Intermediate", "avatar": "" },
-        { "name": "Crane", "os": "Linux", "difficulty": "Intermediate", "avatar": "" },
-        { "name": "Levram", "os": "Linux", "difficulty": "Intermediate", "avatar": "" },
-        { "name": "Extplorer", "os": "Linux", "difficulty": "Intermediate", "avatar": "" },
-        { "name": "Hub", "os": "Linux", "difficulty": "Intermediate", "avatar": "" },
-        { "name": "Image", "os": "Linux", "difficulty": "Intermediate", "avatar": "" },
-        { "name": "law", "os": "Linux", "difficulty": "Intermediate", "avatar": "" },
-        { "name": "Lavita", "os": "Linux", "difficulty": "Intermediate", "avatar": "" },
-        { "name": "PC", "os": "Linux", "difficulty": "Intermediate", "avatar": "" },
-        { "name": "Fired", "os": "Linux", "difficulty": "Intermediate", "avatar": "" },
-        { "name": "Press", "os": "Linux", "difficulty": "Intermediate", "avatar": "" },
-        { "name": "Scrutiny", "os": "Linux", "difficulty": "Intermediate", "avatar": "" },
-        { "name": "RubyDome", "os": "Linux", "difficulty": "Intermediate", "avatar": "" },
-        { "name": "Zipper", "os": "Linux", "difficulty": "Intermediate", "avatar": "" },
-        { "name": "Flu", "os": "Linux", "difficulty": "Intermediate", "avatar": "" },
-        { "name": "Ochima", "os": "Linux", "difficulty": "Intermediate", "avatar": "" },
-        { "name": "PyLoader", "os": "Linux", "difficulty": "Intermediate", "avatar": "" },
-        { "name": "Plum", "os": "Linux", "difficulty": "Intermediate", "avatar": "" },
-        { "name": "SPX", "os": "Linux", "difficulty": "Intermediate", "avatar": "" },
-        { "name": "Jordak", "os": "Linux", "difficulty": "Intermediate", "avatar": "" },
-        { "name": "BitForge", "os": "Linux", "difficulty": "Intermediate", "avatar": "" },
-        { "name": "Vmdak", "os": "Linux", "difficulty": "Intermediate", "avatar": "" }
-      ]
-    },
-    {
-      "name": "Windows Boxes",
-      "labs": [
-        { "name": "Helpdesk", "os": "Windows", "difficulty": "Intermediate", "avatar": "" },
-        { "name": "Algernon", "os": "Windows", "difficulty": "Intermediate", "avatar": "" },
-        { "name": "Authby", "os": "Windows", "difficulty": "Easy", "avatar": "" },
-        { "name": "Craft", "os": "Windows", "difficulty": "Intermediate", "avatar": "" },
-        { "name": "Hutch", "os": "Windows", "difficulty": "Intermediate", "avatar": "" },
-        { "name": "Internal", "os": "Windows", "difficulty": "Intermediate", "avatar": "" },
-        { "name": "Jacko", "os": "Windows", "difficulty": "Intermediate", "avatar": "" },
-        { "name": "Kevin", "os": "Windows", "difficulty": "Intermediate", "avatar": "" },
-        { "name": "Resourced", "os": "Windows", "difficulty": "Intermediate", "avatar": "" },
-        { "name": "Squid", "os": "Windows", "difficulty": "Intermediate", "avatar": "" },
-        { "name": "DVR4", "os": "Windows", "difficulty": "Intermediate", "avatar": "" },
-        { "name": "Hepet", "os": "Windows", "difficulty": "Active Directory", "avatar": "" },
-        { "name": "Shenzi", "os": "Windows", "difficulty": "Intermediate", "avatar": "" },
-        { "name": "Nickel", "os": "Windows", "difficulty": "Intermediate", "avatar": "" },
-        { "name": "Slort", "os": "Windows", "difficulty": "Intermediate", "avatar": "" },
-        { "name": "MedJed", "os": "Windows", "difficulty": "Intermediate", "avatar": "" }
-      ]
-    },
-    {
-      "name": "Windows Active Directory Boxes",
-      "labs": [
-        { "name": "Access", "os": "AD", "difficulty": "Easy", "avatar": "" },
-        { "name": "Heist", "os": "AD", "difficulty": "Medium", "avatar": "" },
-        { "name": "Vault", "os": "AD", "difficulty": "Medium", "avatar": "" },
-        { "name": "Nagoya", "os": "AD", "difficulty": "Medium", "avatar": "" },
-        { "name": "Hokkaido (Retired for now)", "os": "AD", "difficulty": "Medium", "avatar": "" }
-      ]
-    },
-    {
-      "name": "Post OSCP Section. Challenging yourself",
-      "labs": [
-        { "name": "Osaka", "os": "Windows", "difficulty": "Hard", "avatar": "" },
-        { "name": "ProStore", "os": "Linux", "difficulty": "Hard", "avatar": "" },
-        { "name": "RPC1", "os": "Linux", "difficulty": "Hard", "avatar": "" },
-        { "name": "Symbolic", "os": "Windows", "difficulty": "Hard", "avatar": "" },
-        { "name": "Upsploit", "os": "Linux", "difficulty": "Hard", "avatar": "" },
-        { "name": "Validator", "os": "Linux", "difficulty": "Hard", "avatar": "" },
-        { "name": "GLPI", "os": "Linux", "difficulty": "Hard", "avatar": "" },
-        { "name": "Marshalled", "os": "Linux", "difficulty": "Hard", "avatar": "" },
-        { "name": "Educated", "os": "Linux", "difficulty": "Hard", "avatar": "" },
-        { "name": "Kyoto", "os": "Windows", "difficulty": "Buffer Overflow", "avatar": "" },
-        { "name": "Nara", "os": "AD", "difficulty": "Hard", "avatar": "" }
-      ]
-    }
-  ]
+	"listName": "Proving Grounds Practice",
+	"categories": [
+		{
+			"name": "Linux Boxes",
+			"labs": [
+				{ "name": "Twiggy", "os": "Linux", "difficulty": "Intermediate", "avatar": "" },
+				{ "name": "Exfiltrated", "os": "Linux", "difficulty": "Intermediate", "avatar": "" },
+				{ "name": "Pelican", "os": "Linux", "difficulty": "Intermediate", "avatar": "" },
+				{ "name": "Astronaut", "os": "Linux", "difficulty": "Intermediate", "avatar": "" },
+				{ "name": "Blackgate", "os": "Linux", "difficulty": "Intermediate", "avatar": "" },
+				{ "name": "Boolean", "os": "Linux", "difficulty": "Intermediate", "avatar": "" },
+				{ "name": "Clue", "os": "Linux", "difficulty": "Intermediate", "avatar": "" },
+				{ "name": "Cockpit", "os": "Linux", "difficulty": "Intermediate", "avatar": "" },
+				{ "name": "Codo", "os": "Linux", "difficulty": "Intermediate", "avatar": "" },
+				{ "name": "Crane", "os": "Linux", "difficulty": "Intermediate", "avatar": "" },
+				{ "name": "Levram", "os": "Linux", "difficulty": "Intermediate", "avatar": "" },
+				{ "name": "Extplorer", "os": "Linux", "difficulty": "Intermediate", "avatar": "" },
+				{ "name": "Hub", "os": "Linux", "difficulty": "Intermediate", "avatar": "" },
+				{ "name": "Image", "os": "Linux", "difficulty": "Intermediate", "avatar": "" },
+				{ "name": "law", "os": "Linux", "difficulty": "Intermediate", "avatar": "" },
+				{ "name": "Lavita", "os": "Linux", "difficulty": "Intermediate", "avatar": "" },
+				{ "name": "PC", "os": "Linux", "difficulty": "Intermediate", "avatar": "" },
+				{ "name": "Fired", "os": "Linux", "difficulty": "Intermediate", "avatar": "" },
+				{ "name": "Press", "os": "Linux", "difficulty": "Intermediate", "avatar": "" },
+				{ "name": "Scrutiny", "os": "Linux", "difficulty": "Intermediate", "avatar": "" },
+				{ "name": "RubyDome", "os": "Linux", "difficulty": "Intermediate", "avatar": "" },
+				{ "name": "Zipper", "os": "Linux", "difficulty": "Intermediate", "avatar": "" },
+				{ "name": "Flu", "os": "Linux", "difficulty": "Intermediate", "avatar": "" },
+				{ "name": "Ochima", "os": "Linux", "difficulty": "Intermediate", "avatar": "" },
+				{ "name": "PyLoader", "os": "Linux", "difficulty": "Intermediate", "avatar": "" },
+				{ "name": "Plum", "os": "Linux", "difficulty": "Intermediate", "avatar": "" },
+				{ "name": "SPX", "os": "Linux", "difficulty": "Intermediate", "avatar": "" },
+				{ "name": "Jordak", "os": "Linux", "difficulty": "Intermediate", "avatar": "" },
+				{ "name": "BitForge", "os": "Linux", "difficulty": "Intermediate", "avatar": "" },
+				{ "name": "Vmdak", "os": "Linux", "difficulty": "Intermediate", "avatar": "" }
+			]
+		},
+		{
+			"name": "Windows Boxes",
+			"labs": [
+				{ "name": "Helpdesk", "os": "Windows", "difficulty": "Intermediate", "avatar": "" },
+				{ "name": "Algernon", "os": "Windows", "difficulty": "Intermediate", "avatar": "" },
+				{ "name": "Authby", "os": "Windows", "difficulty": "Easy", "avatar": "" },
+				{ "name": "Craft", "os": "Windows", "difficulty": "Intermediate", "avatar": "" },
+				{ "name": "Hutch", "os": "Windows", "difficulty": "Intermediate", "avatar": "" },
+				{ "name": "Internal", "os": "Windows", "difficulty": "Intermediate", "avatar": "" },
+				{ "name": "Jacko", "os": "Windows", "difficulty": "Intermediate", "avatar": "" },
+				{ "name": "Kevin", "os": "Windows", "difficulty": "Intermediate", "avatar": "" },
+				{ "name": "Resourced", "os": "Windows", "difficulty": "Intermediate", "avatar": "" },
+				{ "name": "Squid", "os": "Windows", "difficulty": "Intermediate", "avatar": "" },
+				{ "name": "DVR4", "os": "Windows", "difficulty": "Intermediate", "avatar": "" },
+				{ "name": "Hepet", "os": "Windows", "difficulty": "Active Directory", "avatar": "" },
+				{ "name": "Shenzi", "os": "Windows", "difficulty": "Intermediate", "avatar": "" },
+				{ "name": "Nickel", "os": "Windows", "difficulty": "Intermediate", "avatar": "" },
+				{ "name": "Slort", "os": "Windows", "difficulty": "Intermediate", "avatar": "" },
+				{ "name": "MedJed", "os": "Windows", "difficulty": "Intermediate", "avatar": "" }
+			]
+		},
+		{
+			"name": "Windows Active Directory Boxes",
+			"labs": [
+				{ "name": "Access", "os": "AD", "difficulty": "Easy", "avatar": "" },
+				{ "name": "Heist", "os": "AD", "difficulty": "Medium", "avatar": "" },
+				{ "name": "Vault", "os": "AD", "difficulty": "Medium", "avatar": "" },
+				{ "name": "Nagoya", "os": "AD", "difficulty": "Medium", "avatar": "" },
+				{ "name": "Hokkaido (Retired for now)", "os": "AD", "difficulty": "Medium", "avatar": "" }
+			]
+		},
+		{
+			"name": "Post OSCP Section. Challenging yourself",
+			"labs": [
+				{ "name": "Osaka", "os": "Windows", "difficulty": "Hard", "avatar": "" },
+				{ "name": "ProStore", "os": "Linux", "difficulty": "Hard", "avatar": "" },
+				{ "name": "RPC1", "os": "Linux", "difficulty": "Hard", "avatar": "" },
+				{ "name": "Symbolic", "os": "Windows", "difficulty": "Hard", "avatar": "" },
+				{ "name": "Upsploit", "os": "Linux", "difficulty": "Hard", "avatar": "" },
+				{ "name": "Validator", "os": "Linux", "difficulty": "Hard", "avatar": "" },
+				{ "name": "GLPI", "os": "Linux", "difficulty": "Hard", "avatar": "" },
+				{ "name": "Marshalled", "os": "Linux", "difficulty": "Hard", "avatar": "" },
+				{ "name": "Educated", "os": "Linux", "difficulty": "Hard", "avatar": "" },
+				{ "name": "Kyoto", "os": "Windows", "difficulty": "Buffer Overflow", "avatar": "" },
+				{ "name": "Nara", "os": "AD", "difficulty": "Hard", "avatar": "" }
+			]
+		}
+	]
 }

--- a/src/lib/markdown.js
+++ b/src/lib/markdown.js
@@ -1,0 +1,137 @@
+const screenshotToken = (path) => `[[IMG:${path}]]`;
+
+const escapeHtml = (str = '') =>
+	str
+		.replace(/&/g, '&amp;')
+		.replace(/</g, '&lt;')
+		.replace(/>/g, '&gt;')
+		.replace(/"/g, '&quot;')
+		.replace(/'/g, '&#39;');
+
+const escapeAttribute = (str = '') => escapeHtml(str).replace(/`/g, '&#96;');
+
+const processInline = (text = '') => {
+	const codeSegments = [];
+	let placeholderText = text.replace(/`([^`]+)`/g, (_, code) => {
+		const token = `@@CODE${codeSegments.length}@@`;
+		codeSegments.push(escapeHtml(code));
+		return token;
+	});
+
+	placeholderText = escapeHtml(placeholderText)
+		.replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>')
+		.replace(/\*(.+?)\*/g, '<em>$1</em>');
+
+	codeSegments.forEach((code, index) => {
+		placeholderText = placeholderText.replace(`@@CODE${index}@@`, `<code>${code}</code>`);
+	});
+
+	return placeholderText;
+};
+
+const replaceScreenshots = (html = '') =>
+	html.replace(/\[\[IMG:(.+?)]]/g, (_, path) => {
+		const cleanPath = path.trim();
+		return `<figure class="note-screenshot"><img src="${escapeAttribute(
+			cleanPath
+		)}" alt="Screenshot ${escapeAttribute(cleanPath)}" /></figure>`;
+	});
+
+export function filterForExamPrep(content = '') {
+	const lines = content.split('\n');
+	const kept = [];
+	let inCodeBlock = false;
+
+	for (const line of lines) {
+		if (line.trim().startsWith('```')) {
+			inCodeBlock = !inCodeBlock;
+			kept.push(line);
+			continue;
+		}
+
+		if (inCodeBlock) {
+			kept.push(line);
+			continue;
+		}
+
+		if (/^- \[[ xX]]/.test(line.trim())) {
+			kept.push(line);
+			continue;
+		}
+
+		if (/^\s*(sudo |# |\$ )/.test(line) || /(nmap|msfconsole|crackmapexec|impacket)/i.test(line)) {
+			kept.push(line);
+			continue;
+		}
+	}
+
+	return kept.length > 0
+		? kept.join('\n')
+		: 'Exam Prep Mode active — walkthrough details are hidden.';
+}
+
+export function renderMarkdown(text = '') {
+	const replacedScreenshots = text.replace(/!\[\[(.+?)\]\]/g, (_, path) => screenshotToken(path));
+	const lines = replacedScreenshots.split('\n');
+	let html = '';
+	let listOpen = false;
+	let inCodeBlock = false;
+
+	const closeListIfNeeded = () => {
+		if (listOpen) {
+			html += '</ul>';
+			listOpen = false;
+		}
+	};
+
+	lines.forEach((rawLine, index) => {
+		const line = rawLine.replace(/\s+$/g, '');
+
+		if (line.trim().startsWith('```')) {
+			if (!inCodeBlock) {
+				closeListIfNeeded();
+				html += '<pre class="note-code"><code>';
+				inCodeBlock = true;
+			} else {
+				html += '</code></pre>';
+				inCodeBlock = false;
+			}
+			return;
+		}
+
+		if (inCodeBlock) {
+			html += `${escapeHtml(line)}\n`;
+			if (index === lines.length - 1) {
+				html += '</code></pre>';
+				inCodeBlock = false;
+			}
+			return;
+		}
+
+		if (/^\s*- /.test(line)) {
+			if (!listOpen) {
+				html += '<ul class="note-list">';
+				listOpen = true;
+			}
+			html += `<li>${processInline(line.replace(/^\s*-\s*/, ''))}</li>`;
+			return;
+		}
+
+		if (line.trim() === '') {
+			closeListIfNeeded();
+			html += '<br />';
+			return;
+		}
+
+		closeListIfNeeded();
+		html += `<p>${processInline(line)}</p>`;
+	});
+
+	closeListIfNeeded();
+
+	if (inCodeBlock) {
+		html += '</code></pre>';
+	}
+
+	return replaceScreenshots(html);
+}

--- a/src/lib/preferencesStore.js
+++ b/src/lib/preferencesStore.js
@@ -1,0 +1,31 @@
+import { writable } from 'svelte/store';
+import { browser } from '$app/environment';
+
+const STORAGE_KEY = 'rootquest-preferences';
+
+const defaultPreferences = {
+	darkMode: false,
+	examPrepMode: false
+};
+
+function loadInitialPreferences() {
+	if (!browser) return defaultPreferences;
+	try {
+		const saved = JSON.parse(localStorage.getItem(STORAGE_KEY) || 'null');
+		if (saved && typeof saved === 'object') {
+			return { ...defaultPreferences, ...saved };
+		}
+	} catch (error) {
+		console.warn('Failed to parse stored preferences', error);
+	}
+	return defaultPreferences;
+}
+
+export const preferences = writable(loadInitialPreferences());
+
+preferences.subscribe((value) => {
+	if (browser) {
+		localStorage.setItem(STORAGE_KEY, JSON.stringify(value));
+		document.documentElement.classList.toggle('dark', Boolean(value?.darkMode));
+	}
+});

--- a/src/lib/stores.js
+++ b/src/lib/stores.js
@@ -1,59 +1,103 @@
 import { writable } from 'svelte/store';
 import { browser } from '$app/environment';
 
-const initialLabs = browser ? JSON.parse(localStorage.getItem('my-advanced-labs') || '[]') : [];
+const STORAGE_KEY = 'my-advanced-labs';
 
-// Ensure all labs have required properties and 'notes' as an array of note objects
-const labsWithNotes = initialLabs.map(lab => {
-    // Defensive check for lab existence and basic properties
-    if (!lab || typeof lab !== 'object') {
-        console.warn('Malformed lab entry found in localStorage:', lab);
-        // Return a default valid lab structure or skip it if it's completely malformed
-        return {
-            id: crypto.randomUUID(), // Ensure a unique ID
-            name: 'Unknown Lab', // Default name
-            os: 'Unknown',
-            difficulty: 'Unknown',
-            avatar: '',
-            source: 'Unknown',
-            category: 'Unknown',
-            completed: false,
-            completedAt: null,
-            notes: []
-        };
-    }
+const initialLabs = browser ? JSON.parse(localStorage.getItem(STORAGE_KEY) || '[]') : [];
 
-    let newNotes;
-    if (Array.isArray(lab.notes)) {
-        newNotes = lab.notes.map(note => ({
-            id: note.id || crypto.randomUUID(), // Add ID if missing
-            content: note.content || '',
-            timestamp: note.timestamp || new Date().toISOString()
-        }));
-    } else if (typeof lab.notes === 'string' && lab.notes !== '') {
-        newNotes = [{ id: crypto.randomUUID(), content: lab.notes, timestamp: new Date().toISOString() }];
-    } else {
-        newNotes = [];
-    }
-
-    return {
-        ...lab,
-        // Ensure core properties exist, defaulting if missing
-        id: lab.id || `${lab.source || 'unknown'}-${lab.name?.toLowerCase().replace(/[\s()]/g, '-') || 'unknown'}-${crypto.randomUUID()}`,
-        name: lab.name || 'Unknown Lab',
-        os: lab.os || 'Unknown',
-        difficulty: lab.difficulty || 'Unknown',
-        source: lab.source || 'Unknown',
-        category: lab.category || 'Unknown',
-        completed: !!lab.completed, // Ensure boolean value
-        notes: newNotes
-    };
+const ensureHistoryEvent = (event) => ({
+	id: event?.id || crypto.randomUUID(),
+	type: event?.type || 'status',
+	status: event?.status ?? null,
+	noteId: event?.noteId ?? null,
+	timestamp: event?.timestamp || new Date().toISOString(),
+	summary: event?.summary || ''
 });
+
+export function normalizeLab(lab) {
+	if (!lab || typeof lab !== 'object') {
+		console.warn('Malformed lab entry found in localStorage:', lab);
+		return {
+			id: crypto.randomUUID(),
+			name: 'Unknown Lab',
+			os: 'Unknown',
+			difficulty: 'Unknown',
+			avatar: '',
+			source: 'Unknown',
+			category: 'Unknown',
+			status: 'not_started',
+			completed: false,
+			completedAt: null,
+			startedAt: null,
+			notes: [],
+			services: [],
+			cves: [],
+			tags: [],
+			history: []
+		};
+	}
+
+	let newNotes;
+	if (Array.isArray(lab.notes)) {
+		newNotes = lab.notes.map((note) => ({
+			id: note.id || crypto.randomUUID(),
+			content: note.content || '',
+			timestamp: note.timestamp || new Date().toISOString()
+		}));
+	} else if (typeof lab.notes === 'string' && lab.notes !== '') {
+		newNotes = [
+			{ id: crypto.randomUUID(), content: lab.notes, timestamp: new Date().toISOString() }
+		];
+	} else {
+		newNotes = [];
+	}
+
+	const statusFromLegacy = lab.status || (lab.completed ? 'owned' : 'not_started');
+	const completedAt =
+		lab.completedAt || (statusFromLegacy === 'owned' ? new Date().toISOString() : null);
+
+	return {
+		...lab,
+		id:
+			lab.id ||
+			`${lab.source || 'unknown'}-${
+				lab.name?.toLowerCase().replace(/[\s()]/g, '-') || 'unknown'
+			}-${crypto.randomUUID()}`,
+		name: lab.name || 'Unknown Lab',
+		os: lab.os || 'Unknown',
+		difficulty: lab.difficulty || 'Unknown',
+		source: lab.source || 'Unknown',
+		category: lab.category || 'Unknown',
+		status: statusFromLegacy,
+		completed: statusFromLegacy === 'owned',
+		startedAt: lab.startedAt || null,
+		completedAt,
+		services: Array.isArray(lab.services) ? lab.services : [],
+		cves: Array.isArray(lab.cves) ? lab.cves : [],
+		tags: Array.isArray(lab.tags) ? lab.tags : [],
+		notes: newNotes,
+		history: Array.isArray(lab.history) ? lab.history.map(ensureHistoryEvent) : []
+	};
+}
+
+export function normalizeLabsCollection(collection) {
+	return Array.isArray(collection) ? collection.map((item) => normalizeLab(item)) : [];
+}
+
+// Ensure all labs have required properties and a consistent schema
+const labsWithNotes = normalizeLabsCollection(initialLabs);
 
 export const labs = writable(labsWithNotes);
 
 labs.subscribe((value) => {
-    if (browser) {
-        localStorage.setItem('my-advanced-labs', JSON.stringify(value));
-    }
+	if (browser) {
+		localStorage.setItem(STORAGE_KEY, JSON.stringify(value));
+	}
 });
+
+export function recordLabEvent(lab, event) {
+	return {
+		...lab,
+		history: [...(lab.history || []), ensureHistoryEvent(event)]
+	};
+}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,35 +1,193 @@
 <script>
-  import "../app.css";
-  import { RotateCw } from 'lucide-svelte';
+	import '../app.css';
+	import {
+		RotateCw,
+		MoonStar,
+		Sun,
+		LayoutDashboard,
+		LineChart,
+		NotebookPen,
+		Upload,
+		Download
+	} from 'lucide-svelte';
+	import { onMount } from 'svelte';
+	import { get } from 'svelte/store';
+	import { goto } from '$app/navigation';
+	import { page } from '$app/stores';
+	import { browser } from '$app/environment';
+	import clsx from 'clsx';
 
-  function resetData() {
-    if (confirm('Are you sure you want to reset all data?')) {
-        localStorage.removeItem('my-advanced-labs');
-        window.location.reload();
-    }
-  }
+	import { preferences } from '$lib/preferencesStore.js';
+	import { labs, normalizeLabsCollection } from '$lib/stores.js';
+
+	let filePicker;
+
+	const navLinks = [
+		{ href: '/', label: 'Dashboard', icon: LayoutDashboard },
+		{ href: '/stats', label: 'Timeline & Graphs', icon: LineChart },
+		{ href: '/writeups', label: 'Blog Mode', icon: NotebookPen }
+	];
+
+	onMount(() => {
+		if (browser) {
+			const currentPreferences = get(preferences);
+			document.documentElement.classList.toggle('dark', Boolean(currentPreferences.darkMode));
+		}
+	});
+
+	function resetData() {
+		if (confirm('Are you sure you want to reset all data?')) {
+			localStorage.removeItem('my-advanced-labs');
+			window.location.reload();
+		}
+	}
+
+	function toggleDarkMode() {
+		preferences.update((current) => ({ ...current, darkMode: !current.darkMode }));
+	}
+
+	function toggleExamPrepMode() {
+		preferences.update((current) => ({ ...current, examPrepMode: !current.examPrepMode }));
+	}
+
+	function exportBackup() {
+		const data = JSON.stringify(get(labs), null, 2);
+		const blob = new Blob([data], { type: 'application/json' });
+		const url = URL.createObjectURL(blob);
+		const link = document.createElement('a');
+		link.href = url;
+		link.download = `rootquest-backup-${new Date().toISOString().split('T')[0]}.json`;
+		link.click();
+		URL.revokeObjectURL(url);
+	}
+
+	function triggerImport() {
+		filePicker?.click();
+	}
+
+	async function importBackup(event) {
+		const file = event?.target?.files?.[0];
+		if (!file) return;
+
+		try {
+			const text = await file.text();
+			const payload = JSON.parse(text);
+			labs.set(normalizeLabsCollection(payload));
+			alert('Backup imported successfully.');
+		} catch (error) {
+			console.error('Failed to import backup', error);
+			alert('Import failed. Ensure the file is a valid Root Quest backup.');
+		} finally {
+			event.target.value = '';
+		}
+	}
+
+	function navigateTo(path) {
+		goto(path);
+	}
 </script>
 
-<div class="flex flex-col min-h-screen bg-slate-50 text-slate-800">
-  <div class="container mx-auto p-4 md:p-8 flex flex-col flex-grow w-full">
-    <header class="flex flex-col sm:flex-row justify-between items-center p-6 rounded-xl bg-white/70 backdrop-blur-lg border border-white/30 shadow-md mb-8">
-      <h1 class="text-3xl font-bold text-slate-900 mb-4 sm:mb-0">
-        <a href="/">🏆 Root Quest V1.0 🛡️</a>
-      </h1>
-      <nav>
-        <button on:click={resetData} title="Reset All Data" class="text-slate-500 font-semibold hover:text-red-500 transition-colors flex items-center gap-2 p-2 rounded-md hover:bg-red-50">
-            <RotateCw size={18} />
-            <span>Reset Data</span>
-        </button>
-      </nav>
-    </header>
+<div
+	class="flex min-h-screen flex-col bg-slate-50 text-slate-800 transition-colors dark:bg-slate-950 dark:text-slate-100"
+>
+	<div class="container mx-auto flex w-full flex-grow flex-col p-4 md:p-8">
+		<header
+			class="mb-8 flex flex-col gap-6 rounded-2xl border border-white/30 bg-white/80 p-6 shadow-lg backdrop-blur-lg lg:flex-row lg:items-center lg:justify-between dark:border-slate-800 dark:bg-slate-900/70"
+		>
+			<div>
+				<h1 class="text-3xl font-bold tracking-tight text-slate-900 dark:text-slate-50">
+					<a href="/">🏆 Root Quest 2.0 🛡️</a>
+				</h1>
+				<p class="mt-2 text-sm text-slate-500 dark:text-slate-400">
+					Track every Hack The Box, Proving Grounds, and OSCP lab with a hacker-grade dashboard.
+				</p>
+			</div>
 
-    <main class="flex-grow">
-      <slot />
-    </main>
-  </div>
+			<nav class="flex flex-1 flex-col gap-4 md:flex-row md:items-center">
+				<div class="flex flex-wrap items-center gap-2">
+					{#each navLinks as nav (nav.href)}
+						<button
+							class={clsx(
+								'inline-flex items-center gap-2 rounded-xl border px-3 py-2 text-sm font-semibold transition-colors',
+								$page.url.pathname === nav.href
+									? 'border-emerald-500 bg-emerald-500 text-white shadow-sm'
+									: 'border-transparent text-slate-600 hover:border-emerald-400/60 hover:bg-emerald-500/10 hover:text-emerald-500 dark:text-slate-300 dark:hover:text-emerald-300'
+							)}
+							on:click={() => navigateTo(nav.href)}
+							type="button"
+						>
+							<svelte:component this={nav.icon} size={18} />
+							<span>{nav.label}</span>
+						</button>
+					{/each}
+				</div>
 
-  <footer class="text-center py-4 text-slate-400 text-sm w-full bg-slate-100 border-t border-slate-200 mt-8">
-    <p>Powered by gudgusguz</p>
-  </footer>
+				<div class="flex flex-wrap items-center gap-2 md:ml-auto">
+					<button
+						on:click={toggleExamPrepMode}
+						class="rounded-xl bg-slate-200/80 px-3 py-2 text-xs font-semibold tracking-wide text-slate-700 uppercase transition-colors hover:bg-emerald-500/20 hover:text-emerald-500 dark:bg-slate-800 dark:text-slate-300 dark:hover:text-emerald-300"
+						type="button"
+					>
+						Exam Prep Mode {#if $preferences.examPrepMode}ON ✅{:else}OFF ❌{/if}
+					</button>
+
+					<button
+						on:click={toggleDarkMode}
+						class="rounded-xl border border-slate-200 p-2 text-slate-600 transition-colors hover:bg-slate-100 dark:border-slate-700 dark:text-slate-200 dark:hover:bg-slate-800"
+						type="button"
+						aria-label="Toggle dark mode"
+					>
+						{#if $preferences.darkMode}
+							<Sun size={18} />
+						{:else}
+							<MoonStar size={18} />
+						{/if}
+					</button>
+
+					<button
+						on:click={exportBackup}
+						class="inline-flex items-center gap-2 rounded-xl border border-slate-200 px-3 py-2 text-slate-600 transition-colors hover:border-emerald-300 hover:text-emerald-500 dark:border-slate-700 dark:text-slate-200 dark:hover:text-emerald-300"
+						type="button"
+					>
+						<Download size={16} /> Backup
+					</button>
+
+					<button
+						on:click={triggerImport}
+						class="inline-flex items-center gap-2 rounded-xl border border-slate-200 px-3 py-2 text-slate-600 transition-colors hover:border-emerald-300 hover:text-emerald-500 dark:border-slate-700 dark:text-slate-200 dark:hover:text-emerald-300"
+						type="button"
+					>
+						<Upload size={16} /> Restore
+					</button>
+
+					<button
+						on:click={resetData}
+						title="Reset All Data"
+						class="inline-flex items-center gap-2 rounded-xl border border-red-200/60 px-3 py-2 text-red-500 transition-colors hover:bg-red-500/10"
+						type="button"
+					>
+						<RotateCw size={16} /> Reset
+					</button>
+				</div>
+			</nav>
+		</header>
+
+		<main class="flex-grow">
+			<slot />
+		</main>
+	</div>
+
+	<footer
+		class="mt-8 w-full border-t border-slate-200/70 bg-slate-100 py-4 text-center text-sm text-slate-400 dark:border-slate-800 dark:bg-slate-900 dark:text-slate-500"
+	>
+		<p>Powered by Root Quest 2.0</p>
+	</footer>
+
+	<input
+		bind:this={filePicker}
+		type="file"
+		accept="application/json"
+		class="hidden"
+		on:change={importBackup}
+	/>
 </div>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,485 +1,985 @@
 <script>
-    import { onMount } from 'svelte';
-    import { labs as labsStore } from '$lib/stores.js';
-    import { ChevronDown, Computer, Bird, Bot, PlusCircle, ExternalLink, NotepadText, Save, X, Trash2, Edit2, Plus, GripVertical } from 'lucide-svelte';
-    import clsx from 'clsx'; // Import clsx
+	import { onMount } from 'svelte';
+	import { get } from 'svelte/store';
+	import clsx from 'clsx';
+	import { labs as labsStore, recordLabEvent, normalizeLab } from '$lib/stores.js';
+	import { preferences } from '$lib/preferencesStore.js';
+	import { filterForExamPrep, renderMarkdown } from '$lib/markdown.js';
+	import {
+		Bird,
+		Bot,
+		ChevronDown,
+		Computer,
+		ExternalLink,
+		GripVertical,
+		NotepadText,
+		Plus,
+		PlusCircle,
+		Save,
+		Search,
+		ShieldCheck,
+		Trash2,
+		X,
+		Edit2
+	} from 'lucide-svelte';
 
-    // Import Data
-    import htbData from '$lib/data/htb_labs.json';
-    import pgPracticeData from '$lib/data/pg_practice_labs.json';
+	import htbData from '$lib/data/htb_labs.json';
+	import pgPracticeData from '$lib/data/pg_practice_labs.json';
+	import oscpData from '$lib/data/oscp_labs.json';
 
-    let activeListKey = 'htb';
-    let activeCategoryName = '';
-    let newLabName = '', newLabDifficulty = 'Easy', newLabOs = '';
-    let showAddForm = false;
+	const MAX_NOTE_LINES = 50;
+	const MAX_NOTE_CHARS = 4000;
+	const STATUS_META = {
+		owned: {
+			label: 'Owned',
+			badge: 'bg-emerald-500/10 text-emerald-500 dark:text-emerald-300',
+			pill: 'bg-emerald-500 text-white',
+			icon: '✅'
+		},
+		in_progress: {
+			label: 'In Progress',
+			badge: 'bg-amber-500/10 text-amber-500 dark:text-amber-300',
+			pill: 'bg-amber-500 text-white',
+			icon: '⏳'
+		},
+		not_started: {
+			label: 'Not Started',
+			badge: 'bg-slate-500/10 text-slate-500 dark:text-slate-300',
+			pill: 'bg-slate-500 text-white',
+			icon: '❌'
+		}
+	};
+	const STATUS_SEQUENCE = ['not_started', 'in_progress', 'owned'];
+	const STATUS_ORDER = ['not_started', 'in_progress', 'owned'];
+	const STATUS_BUTTONS = STATUS_SEQUENCE.map((key) => ({ key, meta: STATUS_META[key] })).filter(
+		(item) => item.meta
+	);
 
-    // State สำหรับ Note Modal
-    let showNoteModal = false;
-    let activeNoteLab = null; // Lab object ที่กำลังเปิด Note Modal
-    
-    // State สำหรับการจัดการ Note รายรายการภายใน Modal
-    let newIndividualNoteContent = ''; // เนื้อหาสำหรับ Note ใหม่ที่กำลังจะเพิ่ม
-    let editingIndividualNoteId = null; // ID ของ Note รายการที่กำลังแก้ไข
-    let editingIndividualNoteContent = ''; // เนื้อหาของ Note รายการที่กำลังแก้ไข
+	const initialData = { htb: htbData, pg: pgPracticeData, oscp: oscpData };
 
-    const MAX_NOTE_LINES = 15;
-    const MAX_NOTE_CHARS = 1000;
+	let activeListKey = 'htb';
+	let activeCategoryName = '';
+	let searchTerm = '';
 
-    const initialData = { htb: htbData, pg: pgPracticeData };
+	let showAddForm = false;
+	let newLabName = '';
+	let newLabDifficulty = 'Easy';
+	let newLabOs = '';
+	let newLabServices = '';
+	let newLabTags = '';
+	let newLabCves = '';
+	let newLabAvatar = '';
 
-    onMount(() => {
-        let needsInitialization = false;
-        if ($labsStore.length === 0) {
-            needsInitialization = true;
-        } else {
-            // Check if existing data is "outdated" or malformed based on new schema
-            // For example, if the first lab doesn't have 'category' or 'notes' is not an array
-            const firstLab = $labsStore[0];
-            if (!firstLab || !firstLab.hasOwnProperty('category') || !Array.isArray(firstLab.notes)) {
-                needsInitialization = true; // Re-initialize if schema is old/malformed
-                console.log('Existing data schema outdated or malformed. Re-initializing...');
-            }
-        }
+	let showNoteModal = false;
+	let activeNoteLab = null;
+	let newIndividualNoteContent = '';
+	let editingIndividualNoteId = null;
+	let editingIndividualNoteContent = '';
 
-        if (needsInitialization) {
-            console.log('Loading initial data...');
-            const allInitialLabs = [];
-            Object.entries(initialData).forEach(([sourceKey, data]) => {
-                data.categories.forEach(category => {
-                    category.labs.forEach(lab => {
-                        allInitialLabs.push({
-                            ...lab,
-                            id: `${sourceKey}-${lab.name.toLowerCase().replace(/[\s()]/g, '-')}-${crypto.randomUUID()}`, // Ensure unique ID
-                            source: sourceKey,
-                            category: category.name,
-                            completed: false,
-                            completedAt: null,
-                            notes: [] // Always initialize notes as an empty array
-                        });
-                    });
-                });
-            });
-            $labsStore = allInitialLabs;
-        } else {
-            // Ensure any existing labs have the 'notes' array property, just in case,
-            // and ensure old labs get proper IDs if they don't have one (though store.js already handles this).
-            $labsStore = $labsStore.map(lab => {
-                let currentNotes = Array.isArray(lab.notes) ? lab.notes : [];
-                if (typeof lab.notes === 'string' && lab.notes !== '') {
-                    currentNotes = [{ id: crypto.randomUUID(), content: lab.notes, timestamp: new Date().toISOString() }];
-                }
-                return {
-                    ...lab,
-                    notes: currentNotes,
-                    id: lab.id || `${lab.source || 'unknown'}-${lab.name?.toLowerCase().replace(/[\s()]/g, '-') || 'unknown'}-${crypto.randomUUID()}` // Ensure ID for old labs too
-                };
-            });
-        }
+	$: activeData = initialData?.[activeListKey];
 
-        if (initialData?.[activeListKey]?.categories?.length > 0) {
-            activeCategoryName = initialData?.[activeListKey]?.categories?.[0]?.name;
-        }
-    });
+	onMount(() => {
+		let needsInitialization = get(labsStore).length === 0;
 
-    $: activeData = initialData?.[activeListKey];
+		if (!needsInitialization) {
+			const sampleLab = get(labsStore)[0];
+			if (!sampleLab || !sampleLab.status || !Array.isArray(sampleLab.notes)) {
+				needsInitialization = true;
+			}
+		}
 
-    $: {
-        // Ensure activeData.categories exists before accessing its properties
-        if (activeData?.categories && activeData.categories.length > 0) {
-            const categoryExists = activeData.categories.some(c => c.name === activeCategoryName);
-            if (!categoryExists) activeCategoryName = activeData.categories?.[0]?.name;
-        }
-    }
+		if (needsInitialization) {
+			const seedLabs = [];
+			Object.entries(initialData).forEach(([sourceKey, data]) => {
+				data.categories.forEach((category) => {
+					category.labs.forEach((lab) => {
+						seedLabs.push(
+							normalizeLab({
+								...lab,
+								id: `${sourceKey}-${lab.name.toLowerCase().replace(/[\s()]/g, '-')}-${crypto.randomUUID()}`,
+								source: sourceKey,
+								category: category.name,
+								avatar: lab.avatar || '',
+								status: 'not_started',
+								completed: false,
+								completedAt: null,
+								startedAt: null,
+								notes: [],
+								history: []
+							})
+						);
+					});
+				});
+			});
+			labsStore.set(seedLabs);
+		}
 
-    $: labsToShow = $labsStore.filter(lab =>
-        // Add robust check here as well to ensure 'lab' is a valid object
-        lab && lab.source === activeListKey && lab.category === activeCategoryName
-    ).sort((a,b) => (b.completed - a.completed) || a.name.localeCompare(b.name));
+		if (initialData?.[activeListKey]?.categories?.length > 0) {
+			activeCategoryName = initialData[activeListKey].categories[0].name;
+		}
+	});
 
-    $: osStats = $labsStore.filter(lab => lab.completed).reduce((acc, lab) => {
-        let osKey = 'Other';
-        const osLower = lab.os?.toLowerCase() || '';
-        if (osLower.includes('ad') || lab.category?.toLowerCase().includes('directory')) osKey = 'Active Directory';
-        else if (osLower.includes('linux')) osKey = 'Linux';
-        else if (osLower.includes('windows')) osKey = 'Windows';
-        if (!acc[osKey]) acc[osKey] = 0;
-        acc[osKey]++;
-        return acc;
-    }, { Linux: 0, Windows: 0, AD: 0 });
+	$: {
+		if (activeData?.categories?.length) {
+			const exists = activeData.categories.some((category) => category.name === activeCategoryName);
+			if (!exists) {
+				activeCategoryName = activeData.categories[0].name;
+			}
+		}
+	}
 
-    function toggleLabStatus(id) {
-        labsStore.update(currentLabs => currentLabs.map(lab => {
-            if (lab.id === id) {
-                const isCompleted = !lab.completed;
-                return { ...lab, completed: isCompleted, completedAt: isCompleted ? new Date().toISOString() : null };
-            }
-            return lab;
-        }));
-    }
+	const statusRank = (status) => STATUS_ORDER.indexOf(status ?? 'not_started');
 
-    function handleAddLab() {
-        if (!newLabName.trim()) return alert('Lab Name is required.');
-        const newLab = {
-            name: newLabName.trim(),
-            difficulty: newLabDifficulty,
-            os: newLabOs.trim(),
-            avatar: '',
-            id: `${activeListKey}-${newLabName.trim().toLowerCase().replace(/[\s()]/g, '-')}-${crypto.randomUUID()}`,
-            source: activeListKey,
-            category: activeCategoryName,
-            completed: false,
-            completedAt: null,
-            notes: [] // Initial notes as an empty array
-        };
-        labsStore.update(currentLabs => [newLab, ...currentLabs]);
-        newLabName = ''; newLabDifficulty = 'Easy'; newLabOs = '';
-        showAddForm = false;
-    }
+	const matchesSearch = (lab) => {
+		if (!searchTerm.trim()) return true;
+		const term = searchTerm.trim().toLowerCase();
+		const haystack = [
+			lab.name,
+			lab.os,
+			lab.difficulty,
+			...(lab.services || []),
+			...(lab.cves || []),
+			...(lab.tags || []),
+			...(lab.notes || []).map((note) => note.content)
+		]
+			.filter(Boolean)
+			.join(' ')
+			.toLowerCase();
+		return haystack.includes(term);
+	};
 
-    function openNoteModal(lab) {
-        activeNoteLab = lab;
-        newIndividualNoteContent = '';
-        editingIndividualNoteId = null;
-        editingIndividualNoteContent = '';
-        showNoteModal = true;
-    }
+	$: labsToShow = $labsStore
+		.filter((lab) => lab.source === activeListKey && lab.category === activeCategoryName)
+		.filter(matchesSearch)
+		.sort((a, b) => statusRank(a.status) - statusRank(b.status) || a.name.localeCompare(b.name));
 
-    function closeNoteModal() {
-        showNoteModal = false;
-        activeNoteLab = null;
-        newIndividualNoteContent = '';
-        editingIndividualNoteId = null;
-        editingIndividualNoteContent = '';
-    }
+	$: overallStatus = $labsStore.reduce(
+		(acc, lab) => {
+			acc[lab.status || 'not_started'] += 1;
+			return acc;
+		},
+		{ owned: 0, in_progress: 0, not_started: 0 }
+	);
 
-    // --- Individual Note Management Functions ---
+	$: ownedByCategory = (activeData?.categories || []).map((category) => {
+		const labsInCategory = $labsStore.filter(
+			(lab) => lab.source === activeListKey && lab.category === category.name
+		);
+		const owned = labsInCategory.filter((lab) => lab.status === 'owned').length;
+		const inProgress = labsInCategory.filter((lab) => lab.status === 'in_progress').length;
+		const totalReference = Math.max(labsInCategory.length, category.labs?.length || 0);
+		const notStarted = Math.max(totalReference - owned - inProgress, 0);
+		return {
+			name: category.name,
+			total: totalReference,
+			owned,
+			inProgress,
+			notStarted
+		};
+	});
 
-    function addIndividualNote() {
-        if (!newIndividualNoteContent.trim()) return;
+	function parseListInput(input) {
+		return input
+			.split(',')
+			.map((item) => item.trim())
+			.filter(Boolean);
+	}
 
-        const newNote = {
-            id: crypto.randomUUID(), // Generate a unique ID for the new note
-            content: newIndividualNoteContent.trim(),
-            timestamp: new Date().toISOString()
-        };
+	function handleAddLab() {
+		if (!newLabName.trim()) {
+			alert('Lab Name is required.');
+			return;
+		}
 
-        labsStore.update(currentLabs => currentLabs.map(lab => {
-            if (lab.id === activeNoteLab.id) {
-                // Ensure lab.notes is an array before spreading
-                return { ...lab, notes: [...(lab.notes || []), newNote] };
-            }
-            return lab;
-        }));
-        newIndividualNoteContent = ''; // Clear input after adding
-        // Update activeNoteLab to reflect changes immediately in modal
-        activeNoteLab.notes = [...(activeNoteLab.notes || []), newNote];
-    }
+		const timestamp = new Date().toISOString();
+		const newLab = normalizeLab({
+			name: newLabName.trim(),
+			difficulty: newLabDifficulty,
+			os: newLabOs.trim() || 'Unknown',
+			avatar: newLabAvatar.trim(),
+			id: `${activeListKey}-${newLabName
+				.trim()
+				.toLowerCase()
+				.replace(/[\s()]/g, '-')}-${crypto.randomUUID()}`,
+			source: activeListKey,
+			category: activeCategoryName,
+			status: 'not_started',
+			completed: false,
+			completedAt: null,
+			startedAt: null,
+			notes: [],
+			services: parseListInput(newLabServices),
+			cves: parseListInput(newLabCves),
+			tags: parseListInput(newLabTags),
+			history: [
+				{
+					id: crypto.randomUUID(),
+					type: 'status',
+					status: 'not_started',
+					timestamp,
+					summary: 'Lab created'
+				}
+			]
+		});
 
-    function startEditIndividualNote(note) {
-        editingIndividualNoteId = note.id;
-        editingIndividualNoteContent = note.content;
-    }
+		labsStore.update((current) => [newLab, ...current]);
 
-    function saveIndividualNote() {
-        if (!editingIndividualNoteId || !editingIndividualNoteContent.trim()) return;
+		newLabName = '';
+		newLabDifficulty = 'Easy';
+		newLabOs = '';
+		newLabServices = '';
+		newLabTags = '';
+		newLabCves = '';
+		newLabAvatar = '';
+		showAddForm = false;
+	}
 
-        labsStore.update(currentLabs => currentLabs.map(lab => {
-            if (lab.id === activeNoteLab.id) {
-                return {
-                    ...lab,
-                    notes: (lab.notes || []).map(note => // Ensure lab.notes is an array before map
-                        note.id === editingIndividualNoteId
-                            ? { ...note, content: editingIndividualNoteContent.trim(), timestamp: new Date().toISOString() }
-                            : note
-                    )
-                };
-            }
-            return lab;
-        }));
-        // Update activeNoteLab to reflect changes immediately in modal
-        activeNoteLab.notes = (activeNoteLab.notes || []).map(note => // Ensure activeNoteLab.notes is an array before map
-            note.id === editingIndividualNoteId
-                ? { ...note, content: editingIndividualNoteContent.trim(), timestamp: new Date().toISOString() }
-                : note
-        );
+	function setLabStatus(lab, status) {
+		const timestamp = new Date().toISOString();
+		labsStore.update((currentLabs) =>
+			currentLabs.map((item) => {
+				if (item.id !== lab.id) return item;
+				let updated = {
+					...item,
+					status,
+					completed: status === 'owned'
+				};
 
-        cancelEditIndividualNote();
-    }
+				if (status === 'owned') {
+					updated = {
+						...updated,
+						completedAt: timestamp,
+						startedAt: updated.startedAt || timestamp
+					};
+				} else if (status === 'in_progress') {
+					updated = {
+						...updated,
+						startedAt: updated.startedAt || timestamp,
+						completedAt: null
+					};
+				} else {
+					updated = {
+						...updated,
+						startedAt: null,
+						completedAt: null
+					};
+				}
 
-    function cancelEditIndividualNote() {
-        editingIndividualNoteId = null;
-        editingIndividualNoteContent = '';
-    }
+				return recordLabEvent(updated, {
+					type: 'status',
+					status,
+					timestamp,
+					summary: `${item.name} → ${STATUS_META[status].label}`
+				});
+			})
+		);
 
-    function deleteIndividualNote(noteId) {
-        if (confirm('Are you sure you want to delete this note entry?')) {
-            labsStore.update(currentLabs => currentLabs.map(lab => {
-                if (lab.id === activeNoteLab.id) {
-                    return { ...lab, notes: (lab.notes || []).filter(note => note.id !== noteId) }; // Ensure lab.notes is an array before filter
-                }
-                return lab;
-            }));
-            // Update activeNoteLab to reflect changes immediately in modal
-            activeNoteLab.notes = (activeNoteLab.notes || []).filter(note => note.id !== noteId); // Ensure activeNoteLab.notes is an array before filter
-        }
-    }
+		if (showNoteModal) {
+			activeNoteLab = get(labsStore).find((item) => item.id === lab.id) || null;
+		}
+	}
 
-    // --- Validation for new/edited individual notes ---
-    function checkNewNoteContent() {
-        const lines = newIndividualNoteContent.split('\n').length;
-        if (lines > MAX_NOTE_LINES) {
-            newIndividualNoteContent = newIndividualNoteContent.split('\n').slice(0, MAX_NOTE_LINES).join('\n');
-        }
-        if (newIndividualNoteContent.length > MAX_NOTE_CHARS) {
-            newIndividualNoteContent = newIndividualNoteContent.substring(0, MAX_NOTE_CHARS);
-        }
-    }
+	function openNoteModal(lab) {
+		activeNoteLab = get(labsStore).find((item) => item.id === lab.id) || lab;
+		newIndividualNoteContent = '';
+		editingIndividualNoteId = null;
+		editingIndividualNoteContent = '';
+		showNoteModal = true;
+	}
 
-    function checkEditingNoteContent() {
-        const lines = editingIndividualNoteContent.split('\n').length;
-        if (lines > MAX_NOTE_LINES) {
-            editingIndividualNoteContent = editingIndividualNoteContent.split('\n').slice(0, MAX_NOTE_LINES).join('\n');
-        }
-        if (editingIndividualNoteContent.length > MAX_NOTE_CHARS) {
-            editingIndividualNoteContent = editingIndividualNoteContent.substring(0, MAX_NOTE_CHARS);
-        }
-    }
+	function closeNoteModal() {
+		showNoteModal = false;
+		activeNoteLab = null;
+		newIndividualNoteContent = '';
+		editingIndividualNoteId = null;
+		editingIndividualNoteContent = '';
+	}
+
+	function addIndividualNote() {
+		if (!newIndividualNoteContent.trim()) return;
+
+		const timestamp = new Date().toISOString();
+		const newNote = {
+			id: crypto.randomUUID(),
+			content: newIndividualNoteContent.trim(),
+			timestamp
+		};
+
+		labsStore.update((current) =>
+			current.map((lab) => {
+				if (lab.id !== activeNoteLab.id) return lab;
+				const updated = {
+					...lab,
+					notes: [...(lab.notes || []), newNote]
+				};
+				return recordLabEvent(updated, {
+					type: 'note',
+					noteId: newNote.id,
+					timestamp,
+					summary: 'Added note entry'
+				});
+			})
+		);
+
+		activeNoteLab = get(labsStore).find((lab) => lab.id === activeNoteLab.id) || null;
+		newIndividualNoteContent = '';
+	}
+
+	function startEditIndividualNote(note) {
+		editingIndividualNoteId = note.id;
+		editingIndividualNoteContent = note.content;
+	}
+
+	function saveIndividualNote() {
+		if (!editingIndividualNoteId || !editingIndividualNoteContent.trim()) return;
+
+		const timestamp = new Date().toISOString();
+
+		labsStore.update((current) =>
+			current.map((lab) => {
+				if (lab.id !== activeNoteLab.id) return lab;
+				const updated = {
+					...lab,
+					notes: (lab.notes || []).map((note) =>
+						note.id === editingIndividualNoteId
+							? { ...note, content: editingIndividualNoteContent.trim(), timestamp }
+							: note
+					)
+				};
+				return recordLabEvent(updated, {
+					type: 'note_edit',
+					noteId: editingIndividualNoteId,
+					timestamp,
+					summary: 'Edited note entry'
+				});
+			})
+		);
+
+		activeNoteLab = get(labsStore).find((lab) => lab.id === activeNoteLab.id) || null;
+		cancelEditIndividualNote();
+	}
+
+	function cancelEditIndividualNote() {
+		editingIndividualNoteId = null;
+		editingIndividualNoteContent = '';
+	}
+
+	function deleteIndividualNote(noteId) {
+		if (!confirm('Delete this note entry?')) return;
+
+		labsStore.update((current) =>
+			current.map((lab) => {
+				if (lab.id !== activeNoteLab.id) return lab;
+				const updated = {
+					...lab,
+					notes: (lab.notes || []).filter((note) => note.id !== noteId)
+				};
+				return recordLabEvent(updated, {
+					type: 'note_delete',
+					noteId,
+					timestamp: new Date().toISOString(),
+					summary: 'Deleted note entry'
+				});
+			})
+		);
+
+		activeNoteLab = get(labsStore).find((lab) => lab.id === activeNoteLab.id) || null;
+	}
+
+	function checkNewNoteContent() {
+		const lines = newIndividualNoteContent.split('\n').length;
+		if (lines > MAX_NOTE_LINES) {
+			newIndividualNoteContent = newIndividualNoteContent
+				.split('\n')
+				.slice(0, MAX_NOTE_LINES)
+				.join('\n');
+		}
+		if (newIndividualNoteContent.length > MAX_NOTE_CHARS) {
+			newIndividualNoteContent = newIndividualNoteContent.substring(0, MAX_NOTE_CHARS);
+		}
+	}
+
+	function checkEditingNoteContent() {
+		const lines = editingIndividualNoteContent.split('\n').length;
+		if (lines > MAX_NOTE_LINES) {
+			editingIndividualNoteContent = editingIndividualNoteContent
+				.split('\n')
+				.slice(0, MAX_NOTE_LINES)
+				.join('\n');
+		}
+		if (editingIndividualNoteContent.length > MAX_NOTE_CHARS) {
+			editingIndividualNoteContent = editingIndividualNoteContent.substring(0, MAX_NOTE_CHARS);
+		}
+	}
+
+	const buildLabUrl = (lab) => {
+		if (lab.source === 'htb') {
+			return `https://www.hackthebox.com/machines/${encodeURIComponent(lab.name)}`;
+		}
+		if (lab.source === 'pg') {
+			return 'https://portal.offensive-security.com/proving-grounds';
+		}
+		if (lab.source === 'oscp') {
+			return 'https://www.offsec.com/courses/pen-200/';
+		}
+		return '#';
+	};
+
+	const labAvatar = (lab) => {
+		if (lab.avatar) return lab.avatar;
+		if (lab.os?.toLowerCase().includes('linux')) return 'linux';
+		if (lab.os?.toLowerCase().includes('windows')) return 'windows';
+		if (lab.os?.toLowerCase().includes('directory')) return 'ad';
+		return 'generic';
+	};
+
+	const formatTimestamp = (timestamp) => {
+		if (!timestamp) return '—';
+		const date = new Date(timestamp);
+		return `${date.toLocaleDateString()} ${date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}`;
+	};
+
+	const renderNote = (note) => {
+		const source = $preferences.examPrepMode ? filterForExamPrep(note.content) : note.content;
+		return renderMarkdown(source);
+	};
 </script>
 
 <svelte:head>
-    <title>The OSCP Ascent</title>
+	<title>Root Quest 2.0 Dashboard</title>
 </svelte:head>
 
-<div class="mb-8">
-    <label for="list-select" class="block text-sm font-medium text-slate-600 mb-2">Select Target List:</label>
-    <div class="relative">
-        <select id="list-select" bind:value={activeListKey} class="w-full md:w-auto appearance-none bg-white border border-slate-300 text-slate-800 font-semibold py-2 px-4 pr-8 rounded-lg shadow-sm focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:border-emerald-500">
-            {#each Object.entries(initialData) as [key, data]}
-                <option value={key}>{data.listName}</option>
-            {/each}
-        </select>
-        <div class="pointer-events-none absolute inset-y-0 right-0 flex items-center px-2 text-slate-500 md:w-auto w-full">
-            <ChevronDown size={20} />
-        </div>
-    </div>
-</div>
+<section class="space-y-6">
+	<div class="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+		<div class="flex-1">
+			<label
+				for="list-select"
+				class="mb-2 block text-sm font-semibold tracking-wide text-slate-500 uppercase dark:text-slate-400"
+				>Target List</label
+			>
+			<div class="relative">
+				<select
+					id="list-select"
+					bind:value={activeListKey}
+					class="w-full appearance-none rounded-xl border border-slate-200 bg-white px-4 py-2 pr-8 font-semibold text-slate-800 shadow-sm focus:border-emerald-500 focus:ring-2 focus:ring-emerald-500 focus:outline-none md:w-64 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-200"
+				>
+					{#each Object.entries(initialData) as [key, data] (key)}
+						<option value={key}>{data.listName}</option>
+					{/each}
+				</select>
+				<div
+					class="pointer-events-none absolute inset-y-0 right-3 flex items-center text-slate-500"
+				>
+					<ChevronDown size={20} />
+				</div>
+			</div>
+		</div>
 
-<div class="flex flex-col md:flex-row gap-5">
-    <aside class="w-full md:w-60 flex-shrink-0">
-        <div class="bg-white p-4 rounded-xl shadow-sm border border-slate-100 sticky top-8">
-            <div class="flex justify-between items-center mb-4">
-                <h2 class="text-lg font-bold text-slate-800">Categories</h2>
-                <button on:click={() => showAddForm = !showAddForm} class="text-emerald-500 hover:text-emerald-600 transition-colors p-1 rounded-full hover:bg-emerald-100">
-                    <PlusCircle size={24} />
-                </button>
-            </div>
+		<div class="flex-1">
+			<label
+				class="mb-2 block text-sm font-semibold tracking-wide text-slate-500 uppercase dark:text-slate-400"
+				for="search"
+			>
+				Search Labs / CVE / Service
+			</label>
+			<div class="relative">
+				<Search class="absolute top-1/2 left-3 -translate-y-1/2 text-slate-400" size={18} />
+				<input
+					id="search"
+					type="search"
+					placeholder="e.g. Active Directory, CVE-2021-42278, WinRM"
+					bind:value={searchTerm}
+					class="w-full rounded-xl border border-slate-200 bg-white py-2 pr-4 pl-10 text-slate-700 shadow-sm focus:border-emerald-500 focus:ring-2 focus:ring-emerald-500 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-200"
+				/>
+			</div>
+		</div>
+	</div>
 
-            {#if showAddForm}
-            <div class="mb-4 pt-4 border-t border-slate-200">
-                <form on:submit|preventDefault={handleAddLab} class="space-y-4">
-                    <div>
-                        <label for="new-lab-name" class="block text-sm font-medium text-slate-600 mb-1">Lab Name</label>
-                        <input id="new-lab-name" type="text" placeholder="Add to '{activeCategoryName}'..." required bind:value={newLabName} class="w-full p-2 border border-slate-300 rounded-md focus:ring-2 focus:ring-emerald-400 focus:border-emerald-400 transition">
-                    </div>
-                    <div class="grid grid-cols-2 gap-4">
-                        <div>
-                            <label for="new-lab-difficulty" class="block text-sm font-medium text-slate-600 mb-1">Difficulty</label>
-                            <select id="new-lab-difficulty" bind:value={newLabDifficulty} class="w-full p-2 border border-slate-300 rounded-md focus:ring-2 focus:ring-emerald-400 focus:border-emerald-400 transition">
-                                <option value="Easy">Easy</option>
-                                <option value="Medium">Medium</option>
-                                <option value="Intermediate">Intermediate</option>
-                                <option value="Hard">Hard</option>
-                            </select>
-                        </div>
-                        <div>
-                            <label for="new-lab-os" class="block text-sm font-medium text-slate-600 mb-1">OS</label>
-                            <input id="new-lab-os" type="text" placeholder="e.g., Linux" bind:value={newLabOs} class="w-full p-2 border border-slate-300 rounded-md focus:ring-2 focus:ring-emerald-400 focus:border-emerald-400 transition">
-                        </div>
-                    </div>
-                    <button type="submit" class="w-full bg-emerald-500 text-white font-bold p-2 rounded-md hover:bg-emerald-600 transition-colors">Add Lab</button>
-                </form>
-            </div>
-            {/if}
+	<div class="grid grid-cols-1 gap-6 lg:grid-cols-[280px_1fr]">
+		<aside class="space-y-6">
+			<div
+				class="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm dark:border-slate-800 dark:bg-slate-900"
+			>
+				<div class="mb-4 flex items-center justify-between">
+					<h2 class="text-lg font-bold text-slate-800 dark:text-slate-100">Categories</h2>
+					<button
+						on:click={() => (showAddForm = !showAddForm)}
+						class="rounded-full p-2 text-emerald-500 transition-colors hover:bg-emerald-500/10 hover:text-emerald-400"
+						aria-label="Add lab"
+					>
+						<PlusCircle size={22} />
+					</button>
+				</div>
 
-            <nav class="flex flex-col gap-1">
-                {#if activeData}
-                    {#each activeData.categories as category}
-                        <button on:click={() => activeCategoryName = category.name} class="w-full text-left px-3 py-2 text-sm font-semibold rounded-md transition-colors flex justify-between items-center" class:bg-emerald-100={activeCategoryName === category.name} class:text-emerald-700={activeCategoryName === category.name} class:text-slate-600={activeCategoryName !== category.name} class:hover:bg-slate-100={activeCategoryName !== category.name}>
-                            <span>{category.name}</span>
-                            <span class="text-xs bg-slate-200 text-slate-600 rounded-full px-2 py-0.5">{category.labs.length}</span>
-                        </button>
-                    {/each}
-                {/if}
-            </nav>
+				{#if showAddForm}
+					<div class="mb-5 space-y-4 border-t border-slate-200 pt-4 dark:border-slate-800">
+						<h3 class="text-sm font-semibold text-slate-600 uppercase dark:text-slate-400">
+							Quick Add Lab
+						</h3>
+						<form on:submit|preventDefault={handleAddLab} class="space-y-4">
+							<div class="space-y-2">
+								<label
+									for="new-lab-name"
+									class="text-xs font-semibold text-slate-500 uppercase dark:text-slate-400"
+									>Lab Name</label
+								>
+								<input
+									id="new-lab-name"
+									type="text"
+									placeholder={`Add to "${activeCategoryName}"...`}
+									bind:value={newLabName}
+									required
+									class="w-full rounded-lg border border-slate-200 bg-slate-50 px-3 py-2 text-sm focus:border-emerald-500 focus:ring-2 focus:ring-emerald-500 dark:border-slate-700 dark:bg-slate-800"
+								/>
+							</div>
+							<div class="grid grid-cols-2 gap-3">
+								<div class="space-y-2">
+									<label
+										for="new-lab-difficulty"
+										class="text-xs font-semibold text-slate-500 uppercase dark:text-slate-400"
+										>Difficulty</label
+									>
+									<select
+										id="new-lab-difficulty"
+										bind:value={newLabDifficulty}
+										class="w-full rounded-lg border border-slate-200 bg-slate-50 px-3 py-2 text-sm focus:border-emerald-500 focus:ring-2 focus:ring-emerald-500 dark:border-slate-700 dark:bg-slate-800"
+									>
+										<option value="Easy">Easy</option>
+										<option value="Medium">Medium</option>
+										<option value="Intermediate">Intermediate</option>
+										<option value="Hard">Hard</option>
+									</select>
+								</div>
+								<div class="space-y-2">
+									<label
+										for="new-lab-os"
+										class="text-xs font-semibold text-slate-500 uppercase dark:text-slate-400"
+										>OS</label
+									>
+									<input
+										id="new-lab-os"
+										type="text"
+										placeholder="Linux / Windows / AD"
+										bind:value={newLabOs}
+										class="w-full rounded-lg border border-slate-200 bg-slate-50 px-3 py-2 text-sm focus:border-emerald-500 focus:ring-2 focus:ring-emerald-500 dark:border-slate-700 dark:bg-slate-800"
+									/>
+								</div>
+							</div>
+							<div class="space-y-2">
+								<label
+									for="new-lab-services"
+									class="text-xs font-semibold text-slate-500 uppercase dark:text-slate-400"
+									>Services (comma separated)</label
+								>
+								<input
+									id="new-lab-services"
+									type="text"
+									bind:value={newLabServices}
+									placeholder="http, smb, winrm"
+									class="w-full rounded-lg border border-slate-200 bg-slate-50 px-3 py-2 text-sm focus:border-emerald-500 focus:ring-2 focus:ring-emerald-500 dark:border-slate-700 dark:bg-slate-800"
+								/>
+							</div>
+							<div class="space-y-2">
+								<label
+									for="new-lab-cves"
+									class="text-xs font-semibold text-slate-500 uppercase dark:text-slate-400"
+									>CVEs (comma separated)</label
+								>
+								<input
+									id="new-lab-cves"
+									type="text"
+									bind:value={newLabCves}
+									placeholder="CVE-2023-xxxx"
+									class="w-full rounded-lg border border-slate-200 bg-slate-50 px-3 py-2 text-sm focus:border-emerald-500 focus:ring-2 focus:ring-emerald-500 dark:border-slate-700 dark:bg-slate-800"
+								/>
+							</div>
+							<div class="space-y-2">
+								<label
+									for="new-lab-tags"
+									class="text-xs font-semibold text-slate-500 uppercase dark:text-slate-400"
+									>Tags (comma separated)</label
+								>
+								<input
+									id="new-lab-tags"
+									type="text"
+									bind:value={newLabTags}
+									placeholder="pivoting, bloodhound"
+									class="w-full rounded-lg border border-slate-200 bg-slate-50 px-3 py-2 text-sm focus:border-emerald-500 focus:ring-2 focus:ring-emerald-500 dark:border-slate-700 dark:bg-slate-800"
+								/>
+							</div>
+							<div class="space-y-2">
+								<label
+									for="new-lab-avatar"
+									class="text-xs font-semibold text-slate-500 uppercase dark:text-slate-400"
+									>Avatar URL (optional)</label
+								>
+								<input
+									id="new-lab-avatar"
+									type="url"
+									bind:value={newLabAvatar}
+									placeholder="https://..."
+									class="w-full rounded-lg border border-slate-200 bg-slate-50 px-3 py-2 text-sm focus:border-emerald-500 focus:ring-2 focus:ring-emerald-500 dark:border-slate-700 dark:bg-slate-800"
+								/>
+							</div>
+							<button
+								type="submit"
+								class="w-full rounded-lg bg-emerald-500 py-2 font-bold text-white shadow-sm transition-colors hover:bg-emerald-600"
+							>
+								Add Lab
+							</button>
+						</form>
+					</div>
+				{/if}
 
-            <div class="mt-6 pt-4 border-t border-slate-200">
-                <h2 class="text-xl font-bold mb-4 text-slate-800">Scoreboard</h2>
-                <div class="space-y-3 text-sm">
-                    <div class="flex justify-between items-center font-semibold">
-                        <span class="text-base text-emerald-600 flex items-center gap-2">Total Owned</span>
-                        <span class="px-2 py-0.5 rounded-full bg-emerald-100 text-emerald-800">{$labsStore.filter(l => l.completed).length}</span>
-                    </div>
-                    <div class="flex justify-between items-center">
-                        <span class="flex items-center gap-2">
-                        <img src="https://img.icons8.com/?size=100&id=HF4xGsjDERHf&format=png&color=000000" alt="Linux Icon" width="25" height="50" /> Linux</span>
-                        <span class="font-medium">{osStats['Linux'] || 0}</span>
-                    </div>
-                    <div class="flex justify-between items-center">
-                        <span class="flex items-center gap-2">
-                        <img src="https://img.icons8.com/?size=100&id=9Upks1A4mqpl&format=png&color=000000" alt="Windows Icon" width="25" height="50" /> Windows</span>
-                        <span class="font-medium">{osStats['Windows'] || 0}</span>
-                    </div>
-                    <div class="flex justify-between items-center">
-                        <span class="flex items-center gap-2">
-                        <img src="https://img.icons8.com/?size=100&id=XNsUnRhsQAzH&format=png&color=000000" alt="AD Icon" width="25" height="50" /> Active Directory
-                        </span>
-                        <span class="font-medium">{osStats['Active Directory'] || 0}</span>
-                    </div>
-                </div>
-            </div>
-        </div>
-    </aside>
+				<nav class="flex flex-col gap-2">
+					{#each activeData?.categories || [] as category (category.name)}
+						<button
+							on:click={() => (activeCategoryName = category.name)}
+							class={clsx(
+								'flex w-full items-center justify-between rounded-xl px-3 py-2 text-left text-sm font-semibold transition-colors',
+								activeCategoryName === category.name
+									? 'bg-emerald-500/10 text-emerald-600 dark:text-emerald-300'
+									: 'text-slate-600 hover:bg-slate-100/70 dark:text-slate-300 dark:hover:bg-slate-800/70'
+							)}
+						>
+							<span>{category.name}</span>
+							<span
+								class="rounded-full bg-slate-200 px-2 py-0.5 text-xs text-slate-600 dark:bg-slate-800 dark:text-slate-300"
+							>
+								{$labsStore.filter(
+									(lab) => lab.source === activeListKey && lab.category === category.name
+								).length}
+							</span>
+						</button>
+					{/each}
+				</nav>
+			</div>
 
-    <div class="flex-grow">
-        {#if activeCategoryName}
-        <section>
-            <h2 class="text-2xl font-bold mb-4">{activeCategoryName} <span class="text-base font-normal text-slate-500">({labsToShow.length} items)</span></h2>
-            <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-                {#each labsToShow as lab (lab.id)}
-                        <div class={clsx(
-                                "bg-white rounded-xl shadow-md border border-slate-100 transition-all hover:shadow-lg overflow-hidden",
-                                "grid grid-cols-3 grid-rows-3 gap-2 p-3",
-                                { "opacity-60": lab.completed }
-                            )}>
+			<div
+				class="space-y-4 rounded-2xl border border-slate-200 bg-white p-5 shadow-sm dark:border-slate-800 dark:bg-slate-900"
+			>
+				<h2 class="flex items-center gap-2 text-lg font-bold text-slate-800 dark:text-slate-100">
+					<ShieldCheck size={18} /> Scoreboard
+				</h2>
+				<div class="grid grid-cols-3 gap-3 text-center">
+					{#each Object.entries(overallStatus) as [status, count] (status)}
+						<div class="rounded-xl border border-slate-200 p-3 dark:border-slate-800">
+							<p class="text-xs font-semibold text-slate-500 uppercase dark:text-slate-400">
+								{STATUS_META[status].label}
+							</p>
+							<p class="text-2xl font-bold text-slate-800 dark:text-slate-100">{count}</p>
+						</div>
+					{/each}
+				</div>
+				<div class="space-y-3">
+					<h3 class="text-sm font-semibold text-slate-600 uppercase dark:text-slate-400">
+						Owned by Category
+					</h3>
+					<div class="space-y-3">
+						{#each ownedByCategory as category (category.name)}
+							<div>
+								<div class="mb-1 flex justify-between text-xs text-slate-500 dark:text-slate-400">
+									<span>{category.name}</span>
+									<span>{category.owned}/{category.total}</span>
+								</div>
+								<div class="h-2 overflow-hidden rounded-full bg-slate-200 dark:bg-slate-800">
+									<div
+										class="h-full bg-emerald-500 transition-all"
+										style={`width: ${category.total === 0 ? 0 : Math.min(100, (category.owned / category.total) * 100)}%;`}
+									></div>
+								</div>
+								<p class="mt-1 text-xs text-slate-500 dark:text-slate-400">
+									⏳ {category.inProgress} in progress • ❌ {category.notStarted} remaining
+								</p>
+							</div>
+						{/each}
+					</div>
+				</div>
+			</div>
+		</aside>
 
-                        <div class="row-span-3 bg-slate-100 rounded-lg flex items-center justify-center">
-                            {#if lab.avatar}
-                                <img src={lab.avatar} alt="{lab.name} icon" class="w-full h-full object-cover rounded-lg">
-                            {:else}
-                                {#if lab.os?.toLowerCase().includes('linux')} <Bird size={64} class="text-sky-400/70" />
-                                {:else if lab.os?.toLowerCase().includes('windows')} <Computer size={64} class="text-blue-400/70" />
-                                {:else if lab.os?.toLowerCase().includes('ad')} <Bot size={64} class="text-violet-400/70" />
-                                {/if}
-                            {/if}
-                        </div>
+		<div class="space-y-5">
+			<header class="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+				<div>
+					<h2 class="text-2xl font-bold text-slate-800 dark:text-slate-100">
+						{activeCategoryName}
+					</h2>
+					<p class="text-sm text-slate-500 dark:text-slate-400">{labsToShow.length} labs matched</p>
+				</div>
+				<p class="text-xs text-slate-400 uppercase dark:text-slate-500">
+					✅ Owned • ⏳ In Progress • ❌ Not Started — track status and notes with markdown +
+					screenshots
+				</p>
+			</header>
 
-                        <div class="col-span-2 flex justify-between items-start">
-                            <p class="font-bold text-lg text-slate-800 pr-2">{lab.name}</p>
-                            <span class={clsx(
-                                "text-xs font-bold px-2 py-1 rounded-full flex-shrink-0",
-                                { "bg-emerald-100 text-emerald-800": lab.difficulty?.toLowerCase().includes('easy') },
-                                { "bg-amber-100 text-amber-800": lab.difficulty?.toLowerCase().includes('medium') || lab.difficulty?.toLowerCase().includes('intermediate') },
-                                { "bg-red-100 text-red-800": lab.difficulty?.toLowerCase().includes('hard') }
-                            )}
-                            >{lab.difficulty || 'N/A'}</span>
-                        </div>
-
-                        <div class="col-span-2 row-span-2 flex flex-col justify-between">
-                            <p class="text-sm text-slate-500">{lab.os || 'N/A'}</p>
-
-                            <div class="flex justify-between items-center mt-2">
-                                <div class="flex items-center gap-2"> {#if activeListKey === 'htb'}
-                                    <a href={`https://www.hackthebox.com/machines/${lab.name}`} target="_blank" rel="noopener noreferrer" class="p-1 rounded-full text-slate-400 hover:text-emerald-600 hover:bg-emerald-100 transition-colors" title="View on Hack The Box">
-                                        <ExternalLink size={20} />
-                                    </a>
-                                    {/if}
-                                    <button on:click={() => openNoteModal(lab)}
-                                        class={clsx(
-                                            "p-1 rounded-full transition-colors",
-                                            lab.notes.length > 0 ? "text-emerald-600 hover:bg-emerald-100" : "text-slate-400 hover:bg-slate-100"
-                                        )}
-                                        title="{lab.notes.length > 0 ? 'Edit Notes' : 'Add Notes'}"
-                                    >
-                                        <NotepadText size={20} />
-                                    </button>
-                                </div>
-                                <div class="flex items-center gap-2">
-                                    <label for="cb-{lab.id}" class="text-sm font-medium text-slate-600 cursor-pointer">Owned</label>
-                                    <input id="cb-{lab.id}" type="checkbox" checked={lab.completed} on:change={() => toggleLabStatus(lab.id)} class="h-5 w-5 rounded border-slate-300 text-emerald-500 focus:ring-emerald-500 cursor-pointer">
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                {/each}
-            </div>
-        </section>
-        {/if}
-    </div>
-</div>
+			{#if labsToShow.length === 0}
+				<div
+					class="rounded-2xl border border-dashed border-slate-300 bg-white p-6 text-center text-slate-500 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-400"
+				>
+					No labs found. Try adjusting your search or add a new entry.
+				</div>
+			{:else}
+				<div class="grid grid-cols-1 gap-5 md:grid-cols-2 xl:grid-cols-3">
+					{#each labsToShow as lab (lab.id)}
+						<article
+							class={clsx(
+								'group flex flex-col overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm transition-all hover:shadow-xl dark:border-slate-800 dark:bg-slate-900',
+								lab.status === 'owned' ? 'border-emerald-500/50 opacity-80' : ''
+							)}
+						>
+							<div class="flex gap-4 p-4">
+								<div
+									class="flex h-16 w-16 items-center justify-center overflow-hidden rounded-xl bg-slate-100 dark:bg-slate-800"
+								>
+									{#if labAvatar(lab) === 'linux'}
+										<Bird size={42} class="text-emerald-400/70" />
+									{:else if labAvatar(lab) === 'windows'}
+										<Computer size={42} class="text-sky-400/70" />
+									{:else if labAvatar(lab) === 'ad'}
+										<Bot size={42} class="text-violet-400/70" />
+									{:else if lab.avatar}
+										<img
+											src={lab.avatar}
+											alt={`${lab.name} icon`}
+											class="h-full w-full object-cover"
+										/>
+									{:else}
+										<ShieldCheck size={36} class="text-slate-400/70" />
+									{/if}
+								</div>
+								<div class="flex-1">
+									<div class="flex items-start justify-between gap-2">
+										<h3
+											class="text-lg leading-tight font-semibold text-slate-800 dark:text-slate-100"
+										>
+											{lab.name}
+										</h3>
+										<span
+											class={clsx(
+												'rounded-full px-2 py-1 text-xs font-bold',
+												lab.difficulty?.toLowerCase().includes('easy')
+													? 'bg-emerald-500/10 text-emerald-500'
+													: lab.difficulty?.toLowerCase().includes('hard')
+														? 'bg-rose-500/10 text-rose-500'
+														: 'bg-amber-500/10 text-amber-500'
+											)}
+										>
+											{lab.difficulty || 'N/A'}
+										</span>
+									</div>
+									<p class="mt-1 text-sm text-slate-500 dark:text-slate-400">
+										{lab.os || 'Unknown OS'}
+									</p>
+									<div class="mt-2 flex flex-wrap gap-2 text-xs text-slate-500 dark:text-slate-400">
+										{#each lab.services || [] as service (service)}
+											<span class="rounded-full bg-slate-100 px-2 py-0.5 dark:bg-slate-800"
+												>{service}</span
+											>
+										{/each}
+										{#each lab.cves || [] as cve (cve)}
+											<span class="rounded-full bg-rose-500/10 px-2 py-0.5 text-rose-500"
+												>{cve}</span
+											>
+										{/each}
+									</div>
+								</div>
+							</div>
+							<div class="flex flex-1 flex-col gap-3 px-4 pb-4">
+								<div
+									class="flex items-center justify-between text-xs text-slate-500 dark:text-slate-400"
+								>
+									<span
+										class={`inline-flex items-center gap-1 rounded-full px-2 py-1 ${STATUS_META[lab.status].badge}`}
+									>
+										{STATUS_META[lab.status].icon}
+										{STATUS_META[lab.status].label}
+									</span>
+									<span
+										>Updated: {formatTimestamp(
+											lab.history?.at?.(-1)?.timestamp || lab.completedAt || lab.startedAt
+										)}</span
+									>
+								</div>
+								<div class="mt-auto flex items-center justify-between gap-3">
+									<div class="flex items-center gap-2">
+										<a
+											href={buildLabUrl(lab)}
+											target="_blank"
+											rel="noopener noreferrer"
+											class="rounded-full p-2 text-slate-400 transition-colors hover:bg-emerald-500/10 hover:text-emerald-500"
+											title="Open lab portal"
+										>
+											<ExternalLink size={18} />
+										</a>
+										<button
+											on:click={() => openNoteModal(lab)}
+											class={clsx(
+												'rounded-full p-2 transition-colors',
+												(lab.notes || []).length > 0
+													? 'text-emerald-500 hover:bg-emerald-500/10'
+													: 'text-slate-400 hover:bg-slate-100 dark:hover:bg-slate-800'
+											)}
+											title={(lab.notes || []).length > 0 ? 'Manage notes' : 'Add notes'}
+										>
+											<NotepadText size={18} />
+										</button>
+										<a
+											href={`/writeups/${lab.id}`}
+											class="rounded-full p-2 text-slate-400 transition-colors hover:bg-emerald-500/10 hover:text-emerald-500"
+											title="Open blog mode"
+										>
+											<ShieldCheck size={18} />
+										</a>
+									</div>
+									<div class="flex items-center gap-2">
+										{#each STATUS_BUTTONS as { key: statusKey, meta } (statusKey)}
+											<button
+												class={clsx(
+													'rounded-lg border px-2 py-1 text-xs font-semibold transition-colors',
+													lab.status === statusKey
+														? `${meta.pill} border-transparent`
+														: 'border-slate-200 text-slate-500 hover:border-emerald-400 hover:text-emerald-500 dark:border-slate-700 dark:text-slate-300'
+												)}
+												on:click={() => setLabStatus(lab, statusKey)}
+												type="button"
+											>
+												{meta.icon}
+											</button>
+										{/each}
+									</div>
+								</div>
+							</div>
+						</article>
+					{/each}
+				</div>
+			{/if}
+		</div>
+	</div>
+</section>
 
 {#if showNoteModal && activeNoteLab}
-<div class="fixed top-0 left-0 w-full h-full bg-black/50 z-50 flex items-center justify-center p-4">
-    <div class="bg-white rounded-xl shadow-lg border border-slate-100 p-6 w-full max-w-2xl max-h-[90vh] flex flex-col">
-        <h3 class="text-xl font-bold text-slate-800 mb-4 border-b pb-2">{activeNoteLab.name} - Manage Notes</h3>
+	<div class="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4 backdrop-blur-sm">
+		<div
+			class="flex max-h-[90vh] w-full max-w-3xl flex-col rounded-3xl border border-slate-200 bg-white shadow-2xl dark:border-slate-800 dark:bg-slate-950"
+		>
+			<header
+				class="flex items-center justify-between border-b border-slate-200 px-6 py-4 dark:border-slate-800"
+			>
+				<div>
+					<h3 class="text-xl font-bold text-slate-800 dark:text-slate-100">
+						{activeNoteLab.name} — Notes
+					</h3>
+					<p class="text-xs text-slate-500 dark:text-slate-400">
+						Markdown supported. Use `![[Screenshot path]]` for screenshot embeds. Exam Prep Mode
+						hides walkthrough spoilers.
+					</p>
+				</div>
+				<button
+					on:click={closeNoteModal}
+					class="rounded-full p-2 text-slate-400 transition-colors hover:bg-red-500/10 hover:text-red-500"
+				>
+					<X size={18} />
+				</button>
+			</header>
 
-        {#if activeNoteLab.notes && activeNoteLab.notes.length > 0}
-        <div class="flex-grow overflow-y-auto mb-4 p-2 bg-slate-50 border border-slate-200 rounded-md space-y-3">
-            {#each activeNoteLab.notes as note (note.id)}
-            <div class="flex items-start gap-3 p-2 rounded-md hover:bg-slate-100 transition-colors">
-                <div class="flex-shrink-0 text-slate-400 mt-1">
-                    <GripVertical size={16} />
-                </div>
-                <div class="flex-grow">
-                    {#if editingIndividualNoteId === note.id}
-                        <textarea
-                            bind:value={editingIndividualNoteContent}
-                            on:input={checkEditingNoteContent}
-                            class="w-full p-2 border border-slate-300 rounded-md text-sm font-mono focus:ring-2 focus:ring-emerald-400 focus:border-emerald-400"
-                            rows="3"
-                            maxlength={MAX_NOTE_CHARS}
-                        ></textarea>
-                        <div class="flex justify-end gap-2 mt-2">
-                            <button on:click={saveIndividualNote} class="bg-emerald-500 text-white font-bold px-3 py-1 rounded-md hover:bg-emerald-600 transition-colors text-sm">
-                                <Save size={16} class="inline-block mr-1" /> Save
-                            </button>
-                            <button on:click={cancelEditIndividualNote} class="bg-slate-200 text-slate-700 font-bold px-3 py-1 rounded-md hover:bg-slate-300 transition-colors text-sm">
-                                <X size={16} class="inline-block mr-1" /> Cancel
-                            </button>
-                        </div>
-                    {:else}
-                        <p class="whitespace-pre-wrap font-mono text-slate-800 text-sm">{note.content}</p>
-                        <div class="flex justify-end gap-2 text-slate-500 text-xs mt-1">
-                            <span class="mr-auto text-slate-400">{new Date(note.timestamp).toLocaleString()}</span>
-                            <button on:click={() => startEditIndividualNote(note)} class="hover:text-blue-500 p-1 rounded-md hover:bg-blue-50" title="Edit Note">
-                                <Edit2 size={16} />
-                            </button>
-                            <button on:click={() => deleteIndividualNote(note.id)} class="hover:text-red-500 p-1 rounded-md hover:bg-red-50" title="Delete Note">
-                                <Trash2 size={16} />
-                            </button>
-                        </div>
-                    {/if}
-                </div>
-            </div>
-            {/each}
-        </div>
-        {:else}
-        <div class="flex-grow flex items-center justify-center bg-slate-50 border border-slate-200 rounded-md p-3 mb-4">
-            <p class="text-slate-500 italic">No notes added for this lab yet.</p>
-        </div>
-        {/if}
+			<div class="flex-1 space-y-4 overflow-y-auto bg-slate-50/60 p-6 dark:bg-slate-900/40">
+				{#if activeNoteLab.notes && activeNoteLab.notes.length > 0}
+					{#each activeNoteLab.notes as note (note.id)}
+						<div
+							class="space-y-3 rounded-2xl border border-slate-200 bg-white p-4 dark:border-slate-800 dark:bg-slate-900"
+						>
+							<div
+								class="flex items-center justify-between text-xs text-slate-500 dark:text-slate-400"
+							>
+								<span class="inline-flex items-center gap-2"
+									><GripVertical size={14} /> {formatTimestamp(note.timestamp)}</span
+								>
+								<div class="flex items-center gap-2">
+									<button
+										on:click={() => startEditIndividualNote(note)}
+										class="rounded-full p-2 text-slate-400 transition-colors hover:bg-emerald-500/10 hover:text-emerald-500"
+										title="Edit note"
+									>
+										<Edit2 size={16} />
+									</button>
+									<button
+										on:click={() => deleteIndividualNote(note.id)}
+										class="rounded-full p-2 text-slate-400 transition-colors hover:bg-rose-500/10 hover:text-rose-500"
+										title="Delete note"
+									>
+										<Trash2 size={16} />
+									</button>
+								</div>
+							</div>
 
-        <div class="mt-auto pt-4 border-t border-slate-200">
-            <h4 class="font-semibold text-slate-700 mb-2">Add New Note Entry:</h4>
-            <textarea
-                bind:value={newIndividualNoteContent}
-                on:input={checkNewNoteContent}
-                placeholder="Type your new note here (Max {MAX_NOTE_LINES} lines, {MAX_NOTE_CHARS} chars)..."
-                class="w-full p-2 border border-slate-300 rounded-md text-sm mb-2 font-mono focus:ring-2 focus:ring-emerald-400 focus:border-emerald-400"
-                rows="3"
-                maxlength={MAX_NOTE_CHARS}
-            ></textarea>
-            <div class="flex justify-end">
-                <button on:click={addIndividualNote} class="bg-emerald-500 text-white font-bold p-2 rounded-md hover:bg-emerald-600 transition-colors flex items-center gap-1">
-                    <Plus size={18} /> Add Note
-                </button>
-            </div>
-        </div>
+							{#if editingIndividualNoteId === note.id}
+								<textarea
+									bind:value={editingIndividualNoteContent}
+									on:input={checkEditingNoteContent}
+									class="w-full rounded-xl border border-slate-200 bg-slate-50 px-3 py-2 font-mono text-sm focus:border-emerald-500 focus:ring-2 focus:ring-emerald-500 dark:border-slate-800 dark:bg-slate-900"
+									rows="6"
+									maxlength={MAX_NOTE_CHARS}
+								></textarea>
+								<div class="flex justify-end gap-2">
+									<button
+										on:click={saveIndividualNote}
+										class="inline-flex items-center gap-2 rounded-lg bg-emerald-500 px-3 py-2 text-sm font-semibold text-white hover:bg-emerald-600"
+									>
+										<Save size={16} /> Save
+									</button>
+									<button
+										on:click={cancelEditIndividualNote}
+										class="inline-flex items-center gap-2 rounded-lg bg-slate-200 px-3 py-2 text-sm font-semibold text-slate-700 dark:bg-slate-800 dark:text-slate-300"
+									>
+										<X size={16} /> Cancel
+									</button>
+								</div>
+							{:else}
+								<div
+									class="prose prose-sm dark:prose-invert prose-pre:bg-slate-900 prose-pre:text-slate-100 prose-code:text-emerald-500 max-w-none"
+								>
+									<!-- eslint-disable-next-line svelte/no-at-html-tags -->
+									{@html renderNote(note)}
+								</div>
+							{/if}
+						</div>
+					{/each}
+				{:else}
+					<div
+						class="rounded-2xl border border-slate-200 bg-white p-6 text-center text-slate-500 dark:border-slate-800 dark:bg-slate-900 dark:text-slate-400"
+					>
+						No notes yet. Use the composer below to add recon, foothold, and privesc notes.
+					</div>
+				{/if}
+			</div>
 
-        <div class="flex justify-end gap-2 mt-4">
-            <button on:click={closeNoteModal} class="bg-slate-200 text-slate-700 font-bold p-2 rounded-md hover:bg-slate-300 transition-colors">
-                <X size={18} class="inline-block mr-2" /> Close
-            </button>
-        </div>
-    </div>
-</div>
+			<footer class="space-y-3 border-t border-slate-200 p-6 dark:border-slate-800">
+				<h4 class="text-sm font-semibold text-slate-600 uppercase dark:text-slate-300">
+					Add New Entry
+				</h4>
+				<textarea
+					bind:value={newIndividualNoteContent}
+					on:input={checkNewNoteContent}
+					rows="4"
+					maxlength={MAX_NOTE_CHARS}
+					placeholder="Map out attack steps, checklist items, commands, or embed screenshots with ![[Screenshot path]]"
+					class="w-full rounded-xl border border-slate-200 bg-white px-3 py-3 font-mono text-sm focus:border-emerald-500 focus:ring-2 focus:ring-emerald-500 dark:border-slate-800 dark:bg-slate-900"
+				></textarea>
+				<div class="flex items-center justify-between text-xs text-slate-500 dark:text-slate-400">
+					<span>
+						{newIndividualNoteContent.length}/{MAX_NOTE_CHARS} chars • {Math.min(
+							newIndividualNoteContent.split('\n').length,
+							MAX_NOTE_LINES
+						)}/{MAX_NOTE_LINES} lines
+					</span>
+					<button
+						on:click={addIndividualNote}
+						class="inline-flex items-center gap-2 rounded-lg bg-emerald-500 px-4 py-2 text-sm font-semibold text-white hover:bg-emerald-600"
+					>
+						<Plus size={16} /> Add Note
+					</button>
+				</div>
+			</footer>
+		</div>
+	</div>
 {/if}

--- a/src/routes/stats/+page.svelte
+++ b/src/routes/stats/+page.svelte
@@ -1,38 +1,398 @@
 <script>
-    import { labs } from '$lib/stores.js';
+	import { labs } from '$lib/stores.js';
+	import { preferences } from '$lib/preferencesStore.js';
+	import { filterForExamPrep, renderMarkdown } from '$lib/markdown.js';
+	import { CalendarRange, Activity, Target, NotebookPen } from 'lucide-svelte';
 
-    $: completedLabs = $labs.filter(lab => lab.completed && lab.completedAt);
+	const TIMELINE_WIDTH = 960;
+	const TIMELINE_HEIGHT = 360;
+	const PADDING_X = 70;
+	const PADDING_Y = 50;
 
-    $: monthlyStats = completedLabs.reduce((acc, lab) => {
-        const date = new Date(lab.completedAt);
-        const monthYear = date.toLocaleString('en-US', { month: 'long', year: 'numeric' });
-        if (!acc[monthYear]) {
-            acc[monthYear] = 0;
-        }
-        acc[monthYear]++;
-        return acc;
-    }, {});
+	let selectedDate = '';
+	let focusedEvent = null;
+
+	const toDay = (timestamp) => new Date(timestamp).toISOString().split('T')[0];
+	const formatDisplay = (timestamp) =>
+		new Date(timestamp).toLocaleString([], {
+			year: 'numeric',
+			month: 'short',
+			day: 'numeric',
+			hour: '2-digit',
+			minute: '2-digit'
+		});
+
+	const STATUS_COLORS = {
+		owned: '#34d399',
+		in_progress: '#fbbf24',
+		not_started: '#94a3b8'
+	};
+
+	const eventColor = (event) => {
+		if (event.type === 'status') {
+			return STATUS_COLORS[event.status] || '#94a3b8';
+		}
+		if (event.type === 'note') return '#38bdf8';
+		if (event.type === 'note_edit') return '#60a5fa';
+		if (event.type === 'note_delete') return '#f87171';
+		return '#94a3b8';
+	};
+
+	$: categorySummary = $labs.reduce((acc, lab) => {
+		const key = `${lab.source}::${lab.category}`;
+		if (!acc.has(key)) {
+			acc.set(key, {
+				key,
+				category: lab.category,
+				source: lab.source,
+				owned: 0,
+				inProgress: 0,
+				total: 0
+			});
+		}
+		const entry = acc.get(key);
+		entry.total += 1;
+		if (lab.status === 'owned') entry.owned += 1;
+		if (lab.status === 'in_progress') entry.inProgress += 1;
+		return acc;
+	}, new Map());
+
+	$: categoryCards = Array.from(categorySummary.values()).sort((a, b) => b.owned - a.owned);
+
+	$: monthlyOwned = $labs
+		.filter((lab) => lab.completedAt)
+		.map((lab) => ({
+			timestamp: lab.completedAt,
+			label: new Date(lab.completedAt).toLocaleDateString(undefined, {
+				month: 'short',
+				year: 'numeric'
+			})
+		}))
+		.reduce((acc, item) => {
+			const key = `${item.label}::${toDay(item.timestamp).slice(0, 7)}`;
+			if (!acc.has(key)) {
+				acc.set(key, { label: item.label, count: 0, timestamp: item.timestamp });
+			}
+			const entry = acc.get(key);
+			entry.count += 1;
+			return acc;
+		}, new Map());
+
+	$: monthlyCards = Array.from(monthlyOwned.values()).sort(
+		(a, b) => new Date(a.timestamp) - new Date(b.timestamp)
+	);
+
+	$: timelineEvents = $labs
+		.flatMap((lab) => {
+			const noteLookup = new Map((lab.notes || []).map((note) => [note.id, note.content]));
+			return (lab.history || [])
+				.filter(
+					(event) =>
+						event.timestamp && ['status', 'note', 'note_edit', 'note_delete'].includes(event.type)
+				)
+				.map((event) => ({
+					id: `${lab.id}-${event.id}`,
+					labId: lab.id,
+					labName: lab.name,
+					category: lab.category || 'General',
+					timestamp: event.timestamp,
+					type: event.type,
+					status: event.status || lab.status,
+					noteId: event.noteId || null,
+					noteContent: noteLookup.get(event.noteId) || '',
+					summary: event.summary || ''
+				}));
+		})
+		.sort((a, b) => new Date(a.timestamp) - new Date(b.timestamp));
+
+	$: categoriesForTimeline = timelineEvents.length
+		? Array.from(new Set(timelineEvents.map((event) => event.category)))
+		: ['General'];
+
+	$: times = timelineEvents.map((event) => new Date(event.timestamp).getTime());
+	$: minTime = times.length ? Math.min(...times) : Date.now();
+	$: maxTime = times.length ? Math.max(...times) : minTime + 86_400_000;
+	$: timeSpan = Math.max(maxTime - minTime, 1);
+
+	$: rowHeight = (TIMELINE_HEIGHT - PADDING_Y * 2) / categoriesForTimeline.length;
+
+	const toX = (timestamp) => {
+		const time = new Date(timestamp).getTime();
+		const ratio = (time - minTime) / timeSpan;
+		return PADDING_X + ratio * (TIMELINE_WIDTH - PADDING_X * 2);
+	};
+
+	const toY = (category) => {
+		const index = Math.max(categoriesForTimeline.indexOf(category), 0);
+		return PADDING_Y + index * rowHeight + rowHeight / 2;
+	};
+
+	$: tickMarks = timelineEvents.length
+		? Array.from({ length: 5 }, (_, index) => {
+				const value = minTime + (timeSpan * index) / 4;
+				return {
+					x: toX(value),
+					label: new Date(value).toLocaleDateString()
+				};
+			})
+		: [];
+
+	$: selectedEvents = selectedDate
+		? timelineEvents.filter((event) => toDay(event.timestamp) === selectedDate)
+		: [];
+
+	function focusEvent(event) {
+		focusedEvent = event;
+		selectedDate = toDay(event.timestamp);
+	}
+
+	const notePreview = (event) => {
+		if (!event.noteContent) return '';
+		const source = $preferences.examPrepMode
+			? filterForExamPrep(event.noteContent)
+			: event.noteContent;
+		return renderMarkdown(source);
+	};
 </script>
 
 <svelte:head>
-    <title>Stats - Lab Tracker</title>
+	<title>Root Quest 2.0 — Timeline & Graphs</title>
 </svelte:head>
 
-<section class="bg-white p-6 rounded-xl shadow-sm border border-slate-100">
-    <h2 class="text-xl font-bold mb-4">Monthly Completion Stats</h2>
-    <p class="text-slate-600 mb-6">Total Labs Completed: <span class="font-bold text-emerald-500">{completedLabs.length}</span></p>
+<section class="space-y-8">
+	<header class="flex flex-col gap-2">
+		<h1 class="text-3xl font-bold text-slate-900 dark:text-slate-50">
+			Timeline & Graph Control Room
+		</h1>
+		<p class="max-w-2xl text-slate-500 dark:text-slate-400">
+			Visualise your lab grind. Track owned boxes per category, monitor monthly throughput, and
+			drill into every note or status change on the timeline. Exam Prep Mode keeps spoilers hidden
+			while retaining your command checklists.
+		</p>
+	</header>
 
-    {#if Object.keys(monthlyStats).length === 0}
-        <p class="text-center text-slate-500 py-8">No completed labs yet. Go pwn some boxes!</p>
-    {:else}
-        <div class="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
-            {#each Object.entries(monthlyStats) as [month, count]}
-                <div class="bg-slate-50 border border-slate-200 rounded-lg p-4 text-center">
-                    <h3 class="font-semibold text-slate-700">{month}</h3>
-                    <p class="text-4xl font-bold text-emerald-500 my-2">{count}</p>
-                    <span class="text-sm text-slate-500">Lab{count > 1 ? 's' : ''} Completed</span>
-                </div>
-            {/each}
-        </div>
-    {/if}
+	<div class="grid grid-cols-1 gap-5 lg:grid-cols-3">
+		<div
+			class="space-y-3 rounded-2xl border border-slate-200 bg-white p-5 dark:border-slate-800 dark:bg-slate-900"
+		>
+			<div
+				class="flex items-center gap-2 text-sm font-semibold text-slate-600 uppercase dark:text-slate-300"
+			>
+				<Target size={16} /> Owned by Category
+			</div>
+			<div class="space-y-3">
+				{#if categoryCards.length === 0}
+					<p class="text-sm text-slate-500 dark:text-slate-400">
+						No labs tracked yet. Head back to the dashboard to add some targets.
+					</p>
+				{:else}
+					{#each categoryCards.slice(0, 6) as card (card.key)}
+						<div class="space-y-1">
+							<div class="flex justify-between text-xs text-slate-500 dark:text-slate-400">
+								<span>{card.category}</span>
+								<span>{card.owned}/{card.total} owned</span>
+							</div>
+							<div class="h-2 overflow-hidden rounded-full bg-slate-200 dark:bg-slate-800">
+								<div
+									class="h-full bg-emerald-500"
+									style={`width: ${card.total === 0 ? 0 : Math.min(100, (card.owned / card.total) * 100)}%;`}
+								></div>
+							</div>
+							<p class="text-[11px] text-slate-400 dark:text-slate-500">
+								⏳ {card.inProgress} in progress
+							</p>
+						</div>
+					{/each}
+				{/if}
+			</div>
+		</div>
+
+		<div
+			class="space-y-3 rounded-2xl border border-slate-200 bg-white p-5 dark:border-slate-800 dark:bg-slate-900"
+		>
+			<div
+				class="flex items-center gap-2 text-sm font-semibold text-slate-600 uppercase dark:text-slate-300"
+			>
+				<CalendarRange size={16} /> Monthly Owned Pace
+			</div>
+			<div class="space-y-2">
+				{#if monthlyCards.length === 0}
+					<p class="text-sm text-slate-500 dark:text-slate-400">
+						No owned labs yet. Log a completion to unlock this chart.
+					</p>
+				{:else}
+					{#each monthlyCards as month (month.label)}
+						<div
+							class="flex items-center justify-between text-sm text-slate-500 dark:text-slate-300"
+						>
+							<span>{month.label}</span>
+							<span class="font-semibold text-emerald-500">{month.count}</span>
+						</div>
+					{/each}
+				{/if}
+			</div>
+		</div>
+
+		<div
+			class="space-y-3 rounded-2xl border border-slate-200 bg-white p-5 dark:border-slate-800 dark:bg-slate-900"
+		>
+			<div
+				class="flex items-center gap-2 text-sm font-semibold text-slate-600 uppercase dark:text-slate-300"
+			>
+				<Activity size={16} /> Daily Drilldown
+			</div>
+			<label class="text-xs font-semibold text-slate-500 uppercase dark:text-slate-400"
+				>Choose a day</label
+			>
+			<input
+				type="date"
+				bind:value={selectedDate}
+				class="w-full rounded-xl border border-slate-200 bg-slate-50 px-3 py-2 text-sm text-slate-600 focus:border-emerald-500 focus:ring-2 focus:ring-emerald-500 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-200"
+			/>
+			<div class="max-h-40 space-y-2 overflow-y-auto text-sm">
+				{#if selectedEvents.length === 0}
+					<p class="text-sm text-slate-500 dark:text-slate-400">
+						No activity recorded for this date yet.
+					</p>
+				{:else}
+					{#each selectedEvents as event (event.id)}
+						<button
+							class="w-full rounded-xl bg-slate-100 px-3 py-2 text-left transition-colors hover:bg-emerald-500/10 hover:text-emerald-500 dark:bg-slate-800/60 dark:hover:text-emerald-300"
+							on:click={() => (focusedEvent = event)}
+						>
+							<p class="text-xs text-slate-500 uppercase dark:text-slate-400">{event.labName}</p>
+							<p class="text-sm">{event.summary || event.type}</p>
+						</button>
+					{/each}
+				{/if}
+			</div>
+		</div>
+	</div>
+
+	<section
+		class="space-y-5 rounded-3xl border border-slate-200 bg-white p-6 dark:border-slate-800 dark:bg-slate-900"
+	>
+		<header class="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+			<h2 class="text-2xl font-bold text-slate-800 dark:text-slate-100">Interactive Timeline</h2>
+			<p class="max-w-2xl text-sm text-slate-500 dark:text-slate-400">
+				Hover and click points to inspect note drops, status changes, and owned completions.
+				Categories are separated vertically while time flows left to right.
+			</p>
+		</header>
+
+		{#if timelineEvents.length === 0}
+			<div
+				class="rounded-2xl border border-dashed border-slate-300 p-10 text-center text-slate-500 dark:border-slate-700 dark:text-slate-400"
+			>
+				No events captured yet. Update statuses or add notes from the dashboard to populate this
+				view.
+			</div>
+		{:else}
+			<div class="w-full overflow-x-auto">
+				<svg viewBox={`0 0 ${TIMELINE_WIDTH} ${TIMELINE_HEIGHT}`} class="min-w-full">
+					<!-- Category grid lines -->
+					{#each categoriesForTimeline as category, index (category)}
+						<line
+							x1={PADDING_X}
+							y1={PADDING_Y + index * rowHeight}
+							x2={TIMELINE_WIDTH - PADDING_X}
+							y2={PADDING_Y + index * rowHeight}
+							stroke="rgba(148,163,184,0.25)"
+							stroke-width="1"
+						/>
+						<text
+							x={PADDING_X - 15}
+							y={PADDING_Y + index * rowHeight + rowHeight / 2}
+							text-anchor="end"
+							alignment-baseline="middle"
+							class="fill-slate-500 text-xs dark:fill-slate-400"
+						>
+							{category}
+						</text>
+					{/each}
+
+					<!-- Axis line -->
+					<line
+						x1={PADDING_X}
+						y1={TIMELINE_HEIGHT - PADDING_Y}
+						x2={TIMELINE_WIDTH - PADDING_X}
+						y2={TIMELINE_HEIGHT - PADDING_Y}
+						stroke="rgba(148,163,184,0.6)"
+						stroke-width="1.5"
+					/>
+
+					<!-- Tick marks -->
+					{#each tickMarks as tick (tick.label)}
+						<g>
+							<line
+								x1={tick.x}
+								y1={TIMELINE_HEIGHT - PADDING_Y}
+								x2={tick.x}
+								y2={TIMELINE_HEIGHT - PADDING_Y + 8}
+								stroke="rgba(148,163,184,0.8)"
+								stroke-width="1"
+							/>
+							<text
+								x={tick.x}
+								y={TIMELINE_HEIGHT - PADDING_Y + 22}
+								text-anchor="middle"
+								class="fill-slate-500 text-xs dark:fill-slate-400"
+							>
+								{tick.label}
+							</text>
+						</g>
+					{/each}
+
+					<!-- Events -->
+					{#each timelineEvents as event (event.id)}
+						<g on:click={() => focusEvent(event)} class="cursor-pointer">
+							<circle
+								cx={toX(event.timestamp)}
+								cy={toY(event.category)}
+								r={focusedEvent && focusedEvent.id === event.id ? 7 : 5}
+								fill={eventColor(event)}
+								opacity={selectedDate && toDay(event.timestamp) !== selectedDate ? 0.4 : 0.9}
+							/>
+							<title
+								>{event.labName} — {event.summary || event.type} ({formatDisplay(
+									event.timestamp
+								)})</title
+							>
+						</g>
+					{/each}
+				</svg>
+			</div>
+		{/if}
+	</section>
+
+	{#if focusedEvent}
+		<section
+			class="space-y-4 rounded-3xl border border-emerald-200 bg-white p-6 dark:border-emerald-900 dark:bg-slate-900"
+		>
+			<header class="flex items-center gap-3">
+				<NotebookPen size={24} class="text-emerald-500" />
+				<div>
+					<h3 class="text-xl font-semibold text-slate-800 dark:text-slate-100">
+						{focusedEvent.labName}
+					</h3>
+					<p class="text-sm text-slate-500 dark:text-slate-400">
+						{focusedEvent.summary || focusedEvent.type} • {formatDisplay(focusedEvent.timestamp)}
+					</p>
+				</div>
+			</header>
+
+			{#if focusedEvent.noteContent}
+				<div
+					class="prose prose-sm dark:prose-invert prose-pre:bg-slate-900 prose-pre:text-slate-100 prose-code:text-emerald-500 max-w-none"
+				>
+					<!-- eslint-disable-next-line svelte/no-at-html-tags -->
+					{@html notePreview(focusedEvent)}
+				</div>
+			{:else}
+				<p class="text-sm text-slate-500 dark:text-slate-400">
+					No note body captured for this event.
+				</p>
+			{/if}
+		</section>
+	{/if}
 </section>

--- a/src/routes/writeups/+page.svelte
+++ b/src/routes/writeups/+page.svelte
@@ -1,0 +1,108 @@
+<script>
+	import { labs } from '$lib/stores.js';
+	import { preferences } from '$lib/preferencesStore.js';
+	import { filterForExamPrep, renderMarkdown } from '$lib/markdown.js';
+	import { Search, PenLine, ArrowUpRight } from 'lucide-svelte';
+
+	let query = '';
+
+	const matches = (lab) => {
+		if (!query.trim()) return true;
+		const term = query.trim().toLowerCase();
+		const haystack = [
+			lab.name,
+			lab.os,
+			lab.difficulty,
+			...(lab.tags || []),
+			...(lab.cves || []),
+			...(lab.services || []),
+			...(lab.notes || []).map((note) => note.content)
+		]
+			.filter(Boolean)
+			.join(' ')
+			.toLowerCase();
+		return haystack.includes(term);
+	};
+
+	const notePreview = (lab) => {
+		if (!lab.notes?.length) return '';
+		const latest = lab.notes[lab.notes.length - 1];
+		const content = $preferences.examPrepMode ? filterForExamPrep(latest.content) : latest.content;
+		return renderMarkdown(content).slice(0, 600);
+	};
+</script>
+
+<svelte:head>
+	<title>Root Quest 2.0 — Blog Mode</title>
+</svelte:head>
+
+<section class="space-y-6">
+	<header class="space-y-2">
+		<h1 class="text-3xl font-bold text-slate-900 dark:text-slate-50">Blog Mode Writeups</h1>
+		<p class="max-w-2xl text-slate-500 dark:text-slate-400">
+			Generate clean writeups for HTB, Proving Grounds, and OSCP labs. Pick a lab to auto-build
+			Intro, General Understanding, Walkthrough, and Screenshot sections. Exam Prep Mode removes
+			spoiler-heavy sections.
+		</p>
+	</header>
+
+	<div>
+		<label
+			class="mb-2 block text-xs font-semibold text-slate-500 uppercase dark:text-slate-400"
+			for="writeup-search">Search writeups</label
+		>
+		<div class="relative">
+			<Search class="absolute top-1/2 left-3 -translate-y-1/2 text-slate-400" size={18} />
+			<input
+				id="writeup-search"
+				type="search"
+				placeholder="Search by name, service, tag, CVE"
+				bind:value={query}
+				class="w-full rounded-xl border border-slate-200 bg-white py-2 pr-4 pl-10 text-slate-700 shadow-sm focus:border-emerald-500 focus:ring-2 focus:ring-emerald-500 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-200"
+			/>
+		</div>
+	</div>
+
+	<div class="grid grid-cols-1 gap-5 md:grid-cols-2">
+		{#each $labs.filter(matches) as lab (lab.id)}
+			<article
+				class="space-y-3 rounded-2xl border border-slate-200 bg-white p-5 transition-all hover:border-emerald-400/60 hover:shadow-lg dark:border-slate-800 dark:bg-slate-900"
+			>
+				<header class="flex items-start justify-between gap-4">
+					<div>
+						<h2 class="text-xl font-semibold text-slate-800 dark:text-slate-100">{lab.name}</h2>
+						<p class="text-sm text-slate-500 dark:text-slate-400">{lab.category} • {lab.os}</p>
+					</div>
+					<span
+						class="inline-flex items-center gap-2 rounded-full bg-emerald-500/10 px-2 py-1 text-xs font-semibold text-emerald-500"
+					>
+						<PenLine size={14} />
+						{(lab.notes || []).length} notes
+					</span>
+				</header>
+				{#if lab.notes?.length}
+					<div
+						class="prose prose-sm dark:prose-invert prose-pre:bg-slate-900 prose-pre:text-slate-100 prose-code:text-emerald-500 max-h-32 max-w-none overflow-hidden"
+					>
+						<!-- eslint-disable-next-line svelte/no-at-html-tags -->
+						{@html notePreview(lab)}
+					</div>
+				{:else}
+					<p class="text-sm text-slate-500 dark:text-slate-400">
+						No notes yet — add content from the dashboard to unlock a writeup.
+					</p>
+				{/if}
+				<footer class="flex justify-end">
+					<a
+						class="inline-flex items-center gap-2 rounded-xl px-3 py-2 text-sm font-semibold text-emerald-500 hover:text-emerald-400"
+						href={`/writeups/${lab.id}`}
+					>
+						Open writeup <ArrowUpRight size={16} />
+					</a>
+				</footer>
+			</article>
+		{:else}
+			<p class="text-slate-500 dark:text-slate-400">No labs match your query.</p>
+		{/each}
+	</div>
+</section>

--- a/src/routes/writeups/[id]/+page.svelte
+++ b/src/routes/writeups/[id]/+page.svelte
@@ -1,0 +1,229 @@
+<script>
+	import { page } from '$app/stores';
+	import { labs } from '$lib/stores.js';
+	import { preferences } from '$lib/preferencesStore.js';
+	import { filterForExamPrep, renderMarkdown } from '$lib/markdown.js';
+	import { ArrowLeft, Download, ClipboardCopy, ClipboardCheck } from 'lucide-svelte';
+	import { goto } from '$app/navigation';
+	import { onMount } from 'svelte';
+
+	let copied = false;
+
+	$: labId = $page.params.id;
+	$: lab = $labs.find((item) => item.id === labId);
+
+	const formatDate = (timestamp) =>
+		timestamp
+			? new Date(timestamp).toLocaleString([], {
+					year: 'numeric',
+					month: 'short',
+					day: 'numeric',
+					hour: '2-digit',
+					minute: '2-digit'
+				})
+			: '—';
+
+	const cleanList = (items) => (items && items.length ? items.join(', ') : 'N/A');
+
+	const buildWriteupMarkdown = (lab) => {
+		if (!lab) return '';
+		const sortedNotes = [...(lab.notes || [])].sort(
+			(a, b) => new Date(a.timestamp) - new Date(b.timestamp)
+		);
+		const stepByStep = sortedNotes
+			.map((note) => {
+				const content = $preferences.examPrepMode ? filterForExamPrep(note.content) : note.content;
+				return `#### ${new Date(note.timestamp).toLocaleString()}\n${content}`;
+			})
+			.join('\n\n');
+
+		const screenshotLines = [];
+		const commandLines = [];
+
+		sortedNotes.forEach((note) => {
+			const lines = note.content.split('\n');
+			lines.forEach((line) => {
+				const trimmed = line.trim();
+				if (trimmed.includes('![[')) {
+					screenshotLines.push(trimmed);
+				}
+				if (/^(sudo |# |\$ )/.test(trimmed)) {
+					commandLines.push(trimmed);
+				}
+			});
+		});
+
+		const screenshotSection = screenshotLines.length
+			? screenshotLines.join('\n')
+			: 'No screenshots referenced yet.';
+		const commandSection = commandLines.length
+			? commandLines.map((line) => `- \`${line}\``).join('\n')
+			: '- No commands captured yet.';
+
+		return (
+			`# ${lab.name} — Root Quest Writeup\n\n` +
+			`## Intro\n` +
+			`- **Difficulty:** ${lab.difficulty || 'Unknown'}\n` +
+			`- **Operating System:** ${lab.os || 'Unknown'}\n` +
+			`- **Source:** ${lab.source?.toUpperCase() || 'N/A'}\n` +
+			`- **Category:** ${lab.category || 'N/A'}\n` +
+			`- **Services:** ${cleanList(lab.services)}\n` +
+			`- **Tags:** ${cleanList(lab.tags)}\n` +
+			`- **CVEs:** ${cleanList(lab.cves)}\n\n` +
+			`## General Understanding\n` +
+			`- Status: ${lab.status || 'unknown'}\n` +
+			`- Started: ${formatDate(lab.startedAt)}\n` +
+			`- Owned: ${formatDate(lab.completedAt)}\n` +
+			`- Notes Captured: ${(lab.notes || []).length}\n\n` +
+			`## Step-by-step Walkthrough\n` +
+			(stepByStep ||
+				'No walkthrough notes yet. Add note entries from the dashboard to build this section.') +
+			`\n\n## Screenshots + Commands\n` +
+			`${screenshotSection}\n\n### Command Checklist\n${commandSection}\n`
+		);
+	};
+
+	$: markdownWriteup = buildWriteupMarkdown(lab);
+	$: htmlWriteup = markdownWriteup
+		? `<article class="writeup">${renderMarkdown(markdownWriteup)}</article>`
+		: '';
+
+	async function copyMarkdown() {
+		if (!markdownWriteup) return;
+		try {
+			await navigator.clipboard.writeText(markdownWriteup);
+			copied = true;
+			setTimeout(() => (copied = false), 2000);
+		} catch (error) {
+			console.error('Copy failed', error);
+		}
+	}
+
+	function exportWriteup(format) {
+		if (!markdownWriteup) return;
+		const content =
+			format === 'html'
+				? `<!doctype html><html><head><meta charset="utf-8"><title>${lab.name} — Root Quest Writeup</title></head><body>${htmlWriteup}</body></html>`
+				: markdownWriteup;
+		const blob = new Blob([content], { type: format === 'html' ? 'text/html' : 'text/markdown' });
+		const url = URL.createObjectURL(blob);
+		const link = document.createElement('a');
+		link.href = url;
+		link.download = `${lab.name.toLowerCase().replace(/[^a-z0-9]+/g, '-')}-writeup.${format === 'html' ? 'html' : 'md'}`;
+		link.click();
+		URL.revokeObjectURL(url);
+	}
+
+	onMount(() => {
+		if (!lab) {
+			console.warn('Writeup not found, redirecting.');
+			goto('/writeups');
+		}
+	});
+</script>
+
+<svelte:head>
+	<title>{lab ? `${lab.name} — Root Quest Blog Mode` : 'Writeup not found'}</title>
+</svelte:head>
+
+{#if !lab}
+	<section class="p-10 text-center text-slate-500 dark:text-slate-400">
+		<p>Writeup not found. Returning to the writeup index…</p>
+	</section>
+{:else}
+	<section class="space-y-6">
+		<header class="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+			<div>
+				<button
+					class="inline-flex items-center gap-2 text-sm font-semibold text-emerald-500 hover:text-emerald-400"
+					on:click={() => goto('/writeups')}
+				>
+					<ArrowLeft size={16} /> Back to list
+				</button>
+				<h1 class="mt-2 text-3xl font-bold text-slate-900 dark:text-slate-50">{lab.name}</h1>
+				<p class="text-slate-500 dark:text-slate-400">
+					{lab.category} • {lab.os} • {lab.difficulty}
+				</p>
+			</div>
+			<div class="flex flex-wrap gap-2">
+				<button
+					class="inline-flex items-center gap-2 rounded-xl border border-slate-200 px-3 py-2 text-slate-600 hover:border-emerald-400 hover:text-emerald-500 dark:border-slate-700 dark:text-slate-200"
+					on:click={copyMarkdown}
+				>
+					{#if copied}
+						<ClipboardCheck size={16} /> Copied!
+					{:else}
+						<ClipboardCopy size={16} /> Copy Markdown
+					{/if}
+				</button>
+				<button
+					class="inline-flex items-center gap-2 rounded-xl border border-slate-200 px-3 py-2 text-slate-600 hover:border-emerald-400 hover:text-emerald-500 dark:border-slate-700 dark:text-slate-200"
+					on:click={() => exportWriteup('markdown')}
+				>
+					<Download size={16} /> Export .md
+				</button>
+				<button
+					class="inline-flex items-center gap-2 rounded-xl border border-slate-200 px-3 py-2 text-slate-600 hover:border-emerald-400 hover:text-emerald-500 dark:border-slate-700 dark:text-slate-200"
+					on:click={() => exportWriteup('html')}
+				>
+					<Download size={16} /> Export .html
+				</button>
+			</div>
+		</header>
+
+		<section class="grid grid-cols-1 gap-6 lg:grid-cols-[360px_1fr]">
+			<aside
+				class="space-y-3 rounded-2xl border border-slate-200 bg-white p-5 dark:border-slate-800 dark:bg-slate-900"
+			>
+				<h2 class="text-lg font-semibold text-slate-800 dark:text-slate-100">Lab Snapshot</h2>
+				<dl class="space-y-2 text-sm text-slate-600 dark:text-slate-300">
+					<div class="flex justify-between">
+						<dt>Status</dt>
+						<dd>{lab.status}</dd>
+					</div>
+					<div class="flex justify-between">
+						<dt>Started</dt>
+						<dd>{formatDate(lab.startedAt)}</dd>
+					</div>
+					<div class="flex justify-between">
+						<dt>Owned</dt>
+						<dd>{formatDate(lab.completedAt)}</dd>
+					</div>
+					<div class="flex justify-between">
+						<dt>Services</dt>
+						<dd>{cleanList(lab.services)}</dd>
+					</div>
+					<div class="flex justify-between">
+						<dt>Tags</dt>
+						<dd>{cleanList(lab.tags)}</dd>
+					</div>
+					<div class="flex justify-between">
+						<dt>CVEs</dt>
+						<dd>{cleanList(lab.cves)}</dd>
+					</div>
+					<div class="flex justify-between">
+						<dt>Notes</dt>
+						<dd>{(lab.notes || []).length}</dd>
+					</div>
+				</dl>
+			</aside>
+
+			<article
+				class="space-y-4 rounded-2xl border border-slate-200 bg-white p-6 dark:border-slate-800 dark:bg-slate-900"
+			>
+				<h2 class="text-lg font-semibold text-slate-800 dark:text-slate-100">Markdown Source</h2>
+				<textarea
+					class="h-64 w-full rounded-xl border border-slate-200 bg-slate-50 px-3 py-3 font-mono text-sm dark:border-slate-800 dark:bg-slate-900"
+					readonly>{markdownWriteup}</textarea
+				>
+				<h2 class="text-lg font-semibold text-slate-800 dark:text-slate-100">Preview</h2>
+				<div
+					class="prose prose-base dark:prose-invert prose-pre:bg-slate-900 prose-pre:text-slate-100 prose-code:text-emerald-500 max-w-none"
+				>
+					<!-- eslint-disable-next-line svelte/no-at-html-tags -->
+					{@html renderMarkdown(markdownWriteup)}
+				</div>
+			</article>
+		</section>
+	</section>
+{/if}


### PR DESCRIPTION
## Summary
- refresh the Root Quest dashboard with multi-source lab management, search, status controls, markdown notes, and data backup/exam-prep toggles
- add a dedicated timeline & analytics view plus dark-mode styled markdown utilities and OSCP seed data
- introduce Blog Mode to browse labs and export structured writeups with copy/markdown and HTML downloads

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d7ff3e6930832288264fad9de15929