### PR TITLE
Show OS icons on stats timeline

### DIFF
--- a/src/routes/stats/+page.svelte
+++ b/src/routes/stats/+page.svelte
@@ -2,7 +2,16 @@
 	import { labs } from '$lib/stores.js';
 	import { preferences } from '$lib/preferencesStore.js';
 	import { filterForExamPrep, renderMarkdown } from '$lib/markdown.js';
-	import { CalendarRange, Activity, Target, NotebookPen } from 'lucide-svelte';
+	import {
+		CalendarRange,
+		Activity,
+		Target,
+		NotebookPen,
+		Bird,
+		Computer,
+		Bot,
+		Circle as CircleIcon
+	} from 'lucide-svelte';
 
 	const TIMELINE_WIDTH = 960;
 	const TIMELINE_HEIGHT = 360;
@@ -36,6 +45,14 @@
 		if (event.type === 'note_edit') return '#60a5fa';
 		if (event.type === 'note_delete') return '#f87171';
 		return '#94a3b8';
+	};
+
+	const deriveOsKey = (os) => {
+		const value = (os || '').toLowerCase();
+		if (value.includes('linux')) return 'linux';
+		if (value.includes('window')) return 'windows';
+		if (value.includes('directory') || value === 'ad') return 'ad';
+		return 'generic';
 	};
 
 	$: categorySummary = $labs.reduce((acc, lab) => {
@@ -100,7 +117,9 @@
 					status: event.status || lab.status,
 					noteId: event.noteId || null,
 					noteContent: noteLookup.get(event.noteId) || '',
-					summary: event.summary || ''
+					summary: event.summary || '',
+					os: lab.os || 'Unknown',
+					osIcon: deriveOsKey(lab.os)
 				}));
 		})
 		.sort((a, b) => new Date(a.timestamp) - new Date(b.timestamp));
@@ -116,8 +135,30 @@
 
 	$: rowHeight = (TIMELINE_HEIGHT - PADDING_Y * 2) / categoriesForTimeline.length;
 
+	const normalizeToTime = (timestamp) =>
+		timestamp instanceof Date ? timestamp.getTime() : new Date(timestamp).getTime();
+
+	const TIME_GRANULARITY_THRESHOLD = 48 * 60 * 60 * 1000;
+
+	const isEventFocused = (event) => focusedEvent && focusedEvent.id === event.id;
+	const eventRadius = (event) => (isEventFocused(event) ? 11 : 9);
+	const eventIconSize = (event) => (isEventFocused(event) ? 18 : 14);
+
+	const formatTickLabel = (date) => {
+		const value = date instanceof Date ? date : new Date(date);
+		if (timeSpan <= TIME_GRANULARITY_THRESHOLD) {
+			return value.toLocaleString([], {
+				month: 'short',
+				day: 'numeric',
+				hour: '2-digit',
+				minute: '2-digit'
+			});
+		}
+		return value.toLocaleDateString();
+	};
+
 	const toX = (timestamp) => {
-		const time = new Date(timestamp).getTime();
+		const time = normalizeToTime(timestamp);
 		const ratio = (time - minTime) / timeSpan;
 		return PADDING_X + ratio * (TIMELINE_WIDTH - PADDING_X * 2);
 	};
@@ -129,10 +170,11 @@
 
 	$: tickMarks = timelineEvents.length
 		? Array.from({ length: 5 }, (_, index) => {
-				const value = minTime + (timeSpan * index) / 4;
+				const value = new Date(minTime + (timeSpan * index) / 4);
 				return {
+					value,
 					x: toX(value),
-					label: new Date(value).toLocaleDateString()
+					label: formatTickLabel(value)
 				};
 			})
 		: [];
@@ -322,7 +364,7 @@
 					/>
 
 					<!-- Tick marks -->
-					{#each tickMarks as tick (tick.label)}
+					{#each tickMarks as tick (tick.value.toISOString())}
 						<g>
 							<line
 								x1={tick.x}
@@ -349,14 +391,43 @@
 							<circle
 								cx={toX(event.timestamp)}
 								cy={toY(event.category)}
-								r={focusedEvent && focusedEvent.id === event.id ? 7 : 5}
+								r={eventRadius(event)}
 								fill={eventColor(event)}
 								opacity={selectedDate && toDay(event.timestamp) !== selectedDate ? 0.4 : 0.9}
 							/>
+							<foreignObject
+								x={toX(event.timestamp) - eventIconSize(event) / 2}
+								y={toY(event.category) - eventIconSize(event) / 2}
+								width={eventIconSize(event)}
+								height={eventIconSize(event)}
+								pointer-events="none"
+							>
+								<div
+									xmlns="http://www.w3.org/1999/xhtml"
+									class="flex h-full w-full items-center justify-center text-white"
+								>
+									{#if event.osIcon === 'linux'}
+										<Bird size={eventIconSize(event) - 4} strokeWidth={2.5} class="text-white" />
+									{:else if event.osIcon === 'windows'}
+										<Computer
+											size={eventIconSize(event) - 4}
+											strokeWidth={2.5}
+											class="text-white"
+										/>
+									{:else if event.osIcon === 'ad'}
+										<Bot size={eventIconSize(event) - 4} strokeWidth={2.5} class="text-white" />
+									{:else}
+										<CircleIcon
+											size={eventIconSize(event) - 4}
+											strokeWidth={2.5}
+											class="text-white"
+										/>
+									{/if}
+								</div>
+							</foreignObject>
 							<title
-								>{event.labName} — {event.summary || event.type} ({formatDisplay(
-									event.timestamp
-								)})</title
+								>{event.labName} — {event.summary || event.type} ({formatDisplay(event.timestamp)})
+								• {event.os}</title
 							>
 						</g>
 					{/each}


### PR DESCRIPTION
## Summary
- keep stats timeline tick values as Date objects so downstream usage can access consistent metadata
- add time-aware formatting so short-range histories show hour/minute detail while longer spans stay date-only
- ensure axis labels render the new formatter output for clearer same-day differentiation
- replace stats timeline event dots with OS-specific icons while preserving the existing color coding and focus treatment

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d81824cc048322a5e7bfc828c8e2a7