### PR TITLE
Improve stats timeline tick formatting

### DIFF
--- a/src/routes/stats/+page.svelte
+++ b/src/routes/stats/+page.svelte
@@ -2,12 +2,22 @@
 	import { labs } from '$lib/stores.js';
 	import { preferences } from '$lib/preferencesStore.js';
 	import { filterForExamPrep, renderMarkdown } from '$lib/markdown.js';
-	import { CalendarRange, Activity, Target, NotebookPen } from 'lucide-svelte';
+	import {
+		CalendarRange,
+		Activity,
+		Target,
+		NotebookPen,
+		Bird,
+		Computer,
+		Bot,
+		Circle as CircleIcon
+	} from 'lucide-svelte';
 
 	const TIMELINE_WIDTH = 960;
 	const TIMELINE_HEIGHT = 360;
-	const PADDING_X = 70;
+	const PADDING_X = 160;
 	const PADDING_Y = 50;
+	const LABEL_GUTTER = 16;
 
 	let selectedDate = '';
 	let focusedEvent = null;
@@ -36,6 +46,14 @@
 		if (event.type === 'note_edit') return '#60a5fa';
 		if (event.type === 'note_delete') return '#f87171';
 		return '#94a3b8';
+	};
+
+	const deriveOsKey = (os) => {
+		const value = (os || '').toLowerCase();
+		if (value.includes('linux')) return 'linux';
+		if (value.includes('window')) return 'windows';
+		if (value.includes('directory') || value === 'ad') return 'ad';
+		return 'generic';
 	};
 
 	$: categorySummary = $labs.reduce((acc, lab) => {
@@ -100,7 +118,9 @@
 					status: event.status || lab.status,
 					noteId: event.noteId || null,
 					noteContent: noteLookup.get(event.noteId) || '',
-					summary: event.summary || ''
+					summary: event.summary || '',
+					os: lab.os || 'Unknown',
+					osIcon: deriveOsKey(lab.os)
 				}));
 		})
 		.sort((a, b) => new Date(a.timestamp) - new Date(b.timestamp));
@@ -116,8 +136,37 @@
 
 	$: rowHeight = (TIMELINE_HEIGHT - PADDING_Y * 2) / categoriesForTimeline.length;
 
+	const normalizeToTime = (timestamp) =>
+		timestamp instanceof Date ? timestamp.getTime() : new Date(timestamp).getTime();
+
+	const TIME_GRANULARITY_THRESHOLD = 48 * 60 * 60 * 1000;
+
+	const isEventFocused = (event) => focusedEvent && focusedEvent.id === event.id;
+	const eventRadius = (event) => (isEventFocused(event) ? 11 : 9);
+	const eventIconSize = (event) => (isEventFocused(event) ? 18 : 14);
+
+	const shortTickFormatter = new Intl.DateTimeFormat(undefined, {
+		month: 'short',
+		day: 'numeric',
+		hour: '2-digit',
+		minute: '2-digit'
+	});
+
+	const longTickFormatter = new Intl.DateTimeFormat(undefined, {
+		year: 'numeric',
+		month: 'short',
+		day: 'numeric'
+	});
+
+	const formatTickLabel = (date) => {
+		const value = date instanceof Date ? date : new Date(date);
+		return timeSpan <= TIME_GRANULARITY_THRESHOLD
+			? shortTickFormatter.format(value)
+			: longTickFormatter.format(value);
+	};
+
 	const toX = (timestamp) => {
-		const time = new Date(timestamp).getTime();
+		const time = normalizeToTime(timestamp);
 		const ratio = (time - minTime) / timeSpan;
 		return PADDING_X + ratio * (TIMELINE_WIDTH - PADDING_X * 2);
 	};
@@ -129,10 +178,11 @@
 
 	$: tickMarks = timelineEvents.length
 		? Array.from({ length: 5 }, (_, index) => {
-				const value = minTime + (timeSpan * index) / 4;
+				const value = new Date(minTime + (timeSpan * index) / 4);
 				return {
+					value,
 					x: toX(value),
-					label: new Date(value).toLocaleDateString()
+					label: formatTickLabel(value)
 				};
 			})
 		: [];
@@ -300,15 +350,20 @@
 							stroke="rgba(148,163,184,0.25)"
 							stroke-width="1"
 						/>
-						<text
-							x={PADDING_X - 15}
-							y={PADDING_Y + index * rowHeight + rowHeight / 2}
-							text-anchor="end"
-							alignment-baseline="middle"
-							class="fill-slate-500 text-xs dark:fill-slate-400"
+						<foreignObject
+							x={0}
+							y={PADDING_Y + index * rowHeight}
+							width={PADDING_X - LABEL_GUTTER}
+							height={rowHeight}
+							pointer-events="none"
 						>
-							{category}
-						</text>
+							<div
+								xmlns="http://www.w3.org/1999/xhtml"
+								class="flex h-full items-center justify-end pr-2 text-xs text-slate-500 dark:text-slate-400"
+							>
+								<span class="truncate" title={category}>{category}</span>
+							</div>
+						</foreignObject>
 					{/each}
 
 					<!-- Axis line -->
@@ -322,7 +377,7 @@
 					/>
 
 					<!-- Tick marks -->
-					{#each tickMarks as tick (tick.label)}
+					{#each tickMarks as tick (tick.value.getTime())}
 						<g>
 							<line
 								x1={tick.x}
@@ -349,14 +404,43 @@
 							<circle
 								cx={toX(event.timestamp)}
 								cy={toY(event.category)}
-								r={focusedEvent && focusedEvent.id === event.id ? 7 : 5}
+								r={eventRadius(event)}
 								fill={eventColor(event)}
 								opacity={selectedDate && toDay(event.timestamp) !== selectedDate ? 0.4 : 0.9}
 							/>
+							<foreignObject
+								x={toX(event.timestamp) - eventIconSize(event) / 2}
+								y={toY(event.category) - eventIconSize(event) / 2}
+								width={eventIconSize(event)}
+								height={eventIconSize(event)}
+								pointer-events="none"
+							>
+								<div
+									xmlns="http://www.w3.org/1999/xhtml"
+									class="flex h-full w-full items-center justify-center text-white"
+								>
+									{#if event.osIcon === 'linux'}
+										<Bird size={eventIconSize(event) - 4} strokeWidth={2.5} class="text-white" />
+									{:else if event.osIcon === 'windows'}
+										<Computer
+											size={eventIconSize(event) - 4}
+											strokeWidth={2.5}
+											class="text-white"
+										/>
+									{:else if event.osIcon === 'ad'}
+										<Bot size={eventIconSize(event) - 4} strokeWidth={2.5} class="text-white" />
+									{:else}
+										<CircleIcon
+											size={eventIconSize(event) - 4}
+											strokeWidth={2.5}
+											class="text-white"
+										/>
+									{/if}
+								</div>
+							</foreignObject>
 							<title
-								>{event.labName} — {event.summary || event.type} ({formatDisplay(
-									event.timestamp
-								)})</title
+								>{event.labName} — {event.summary || event.type} ({formatDisplay(event.timestamp)})
+								• {event.os}</title
 							>
 						</g>
 					{/each}


### PR DESCRIPTION
## Summary
- introduce dedicated short and long timeline tick formatters so short spans display time of day while longer ranges show full dates

## Testing
- npm run lint
- node - <<'NODE' ... (manual formatter spot-check)


------
https://chatgpt.com/codex/tasks/task_e_68d81824cc048322a5e7bfc828c8e2a7