### PR TITLE
Enable class-based Tailwind dark mode

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,4 @@
+/** @type {import('tailwindcss').Config} */
+export default {
+	darkMode: 'class'
+};


### PR DESCRIPTION
## Summary
- configure Tailwind to use class-based dark mode so the UI reacts to the stored preference

## Testing
- npm run lint *(fails: existing formatting warnings in src/lib/data/pg_practice_labs.json, src/routes/+page.svelte, src/routes/stats/+page.svelte)*

------
https://chatgpt.com/codex/tasks/task_e_68d8f8aac58883229641f175f62a8216