### PR TITLE
Fix dark mode toggle handling and respect saved theme

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -4,6 +4,21 @@
 		<meta charset="utf-8" />
 		<link rel="icon" href="%sveltekit.assets%/favicon.png" />
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<script>
+			(() => {
+				try {
+					const storedTheme = localStorage.getItem('theme');
+					const prefersDark =
+						window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
+					const theme = storedTheme === 'dark' || (!storedTheme && prefersDark) ? 'dark' : 'light';
+					const root = document.documentElement;
+					root.classList.toggle('dark', theme === 'dark');
+					root.style.colorScheme = theme;
+				} catch (error) {
+					console.warn('Unable to apply saved theme preference', error);
+				}
+			})();
+		</script>
 		%sveltekit.head%
 	</head>
 	<body data-sveltekit-preload-data="hover">

--- a/src/lib/preferencesStore.js
+++ b/src/lib/preferencesStore.js
@@ -11,41 +11,97 @@ const defaultPreferences = {
 	examPrepMode: false
 };
 
+const VALID_THEMES = new Set(['light', 'dark']);
+
+function applyTheme(theme) {
+	if (!browser) return;
+
+	const resolvedTheme = VALID_THEMES.has(theme) ? theme : defaultPreferences.theme;
+	const root = document.documentElement;
+	root.classList.toggle('dark', resolvedTheme === 'dark');
+	root.style.colorScheme = resolvedTheme;
+}
+
+function getSystemTheme() {
+	if (!browser || typeof window.matchMedia !== 'function') {
+		return null;
+	}
+
+	return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+}
+
+function resolveStoredTheme(savedPreferences, storedTheme) {
+	if (VALID_THEMES.has(storedTheme)) {
+		return storedTheme;
+	}
+
+	if (savedPreferences && typeof savedPreferences === 'object') {
+		if (VALID_THEMES.has(savedPreferences.theme)) {
+			return savedPreferences.theme;
+		}
+
+		if (savedPreferences.darkMode === true) {
+			return 'dark';
+		}
+	}
+
+	const systemTheme = getSystemTheme();
+	if (systemTheme && VALID_THEMES.has(systemTheme)) {
+		return systemTheme;
+	}
+
+	return defaultPreferences.theme;
+}
+
 function loadInitialPreferences() {
 	if (!browser) return defaultPreferences;
+
 	try {
 		const saved = JSON.parse(localStorage.getItem(STORAGE_KEY) || 'null');
 		const storedTheme = localStorage.getItem(THEME_STORAGE_KEY);
 
-		if (saved && typeof saved === 'object') {
-			const inferredTheme =
-				storedTheme === 'dark' ? 'dark' : saved.theme || defaultPreferences.theme;
-			return {
-				...defaultPreferences,
-				...saved,
-				theme: inferredTheme,
-				darkMode: inferredTheme === 'dark'
-			};
-		}
+		const inferredTheme = resolveStoredTheme(saved, storedTheme);
+		const initialPreferences = {
+			...defaultPreferences,
+			...(saved && typeof saved === 'object' ? saved : {}),
+			theme: inferredTheme,
+			darkMode: inferredTheme === 'dark'
+		};
 
-		if (storedTheme === 'dark') {
-			return { ...defaultPreferences, darkMode: true, theme: 'dark' };
-		}
+		applyTheme(initialPreferences.theme);
+		return initialPreferences;
 	} catch (error) {
 		console.warn('Failed to parse stored preferences', error);
 	}
+
+	applyTheme(defaultPreferences.theme);
 	return defaultPreferences;
 }
 
 export const preferences = writable(loadInitialPreferences());
 
 preferences.subscribe((value) => {
-	if (browser) {
-		const theme = value?.theme === 'dark' || value?.darkMode ? 'dark' : 'light';
-		const nextPreferences = { ...value, theme, darkMode: theme === 'dark' };
-
-		localStorage.setItem(STORAGE_KEY, JSON.stringify(nextPreferences));
-		localStorage.setItem(THEME_STORAGE_KEY, theme);
-		document.documentElement.classList.toggle('dark', theme === 'dark');
+	if (!browser) {
+		return;
 	}
+
+	const theme = value?.theme === 'dark' || value?.darkMode ? 'dark' : 'light';
+	const nextPreferences = { ...defaultPreferences, ...value, theme, darkMode: theme === 'dark' };
+
+	localStorage.setItem(STORAGE_KEY, JSON.stringify(nextPreferences));
+	localStorage.setItem(THEME_STORAGE_KEY, theme);
+	applyTheme(theme);
 });
+
+export function toggleTheme() {
+	preferences.update((current) => {
+		const currentlyDark = current.theme === 'dark' || current.darkMode === true;
+		const nextTheme = currentlyDark ? 'light' : 'dark';
+
+		return {
+			...current,
+			theme: nextTheme,
+			darkMode: nextTheme === 'dark'
+		};
+	});
+}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -17,7 +17,7 @@
 	import { browser } from '$app/environment';
 	import clsx from 'clsx';
 
-	import { preferences } from '$lib/preferencesStore.js';
+	import { preferences, toggleTheme } from '$lib/preferencesStore.js';
 	import { labs, normalizeLabsCollection } from '$lib/stores.js';
 
 	let filePicker;
@@ -56,11 +56,7 @@
 	}
 
 	function toggleDarkMode() {
-		preferences.update((current) => {
-			const currentlyDark = current.theme === 'dark' || current.darkMode;
-			const nextTheme = currentlyDark ? 'light' : 'dark';
-			return { ...current, theme: nextTheme, darkMode: nextTheme === 'dark' };
-		});
+		toggleTheme();
 	}
 
 	function toggleExamPrepMode() {


### PR DESCRIPTION
## Summary
- apply the saved or system theme class before hydration so Tailwind dark styles render immediately
- centralize theme resolution, persistence, and toggling logic in the preferences store
- switch the layout dark mode button to the shared toggle helper

## Testing
- npm run lint *(fails: repository currently has Prettier violations in src/lib/data/pg_practice_labs.json and src/routes/stats/+page.svelte)*

------
https://chatgpt.com/codex/tasks/task_e_68d91d2790c08322b234c90768a7efa8