### PR TITLE
Ensure dark mode applies globally

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -4,6 +4,41 @@
 		<meta charset="utf-8" />
 		<link rel="icon" href="%sveltekit.assets%/favicon.png" />
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<script>
+			(() => {
+				try {
+					const storedTheme = localStorage.getItem('theme');
+					const prefersDark =
+						window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
+					const theme = storedTheme === 'dark' || (!storedTheme && prefersDark) ? 'dark' : 'light';
+					const isDark = theme === 'dark';
+					const root = document.documentElement;
+
+					const applyToBody = (target) => {
+						if (!target) return;
+						target.classList.toggle('dark', isDark);
+						target.dataset.theme = theme;
+						target.style.colorScheme = theme;
+					};
+
+					applyToBody(root);
+
+					if (document.body) {
+						applyToBody(document.body);
+					} else {
+						document.addEventListener(
+							'DOMContentLoaded',
+							() => {
+								applyToBody(document.body);
+							},
+							{ once: true }
+						);
+					}
+				} catch (error) {
+					console.warn('Unable to apply saved theme preference', error);
+				}
+			})();
+		</script>
 		%sveltekit.head%
 	</head>
 	<body data-sveltekit-preload-data="hover">

--- a/src/lib/preferencesStore.js
+++ b/src/lib/preferencesStore.js
@@ -11,41 +11,107 @@ const defaultPreferences = {
 	examPrepMode: false
 };
 
+const VALID_THEMES = new Set(['light', 'dark']);
+
+function applyTheme(theme) {
+	if (!browser) return;
+
+	const resolvedTheme = VALID_THEMES.has(theme) ? theme : defaultPreferences.theme;
+	const isDark = resolvedTheme === 'dark';
+	const root = document.documentElement;
+	const body = document.body;
+
+	root.classList.toggle('dark', isDark);
+	root.dataset.theme = resolvedTheme;
+	root.style.colorScheme = resolvedTheme;
+
+	if (body) {
+		body.classList.toggle('dark', isDark);
+		body.dataset.theme = resolvedTheme;
+		body.style.colorScheme = resolvedTheme;
+	}
+}
+
+function getSystemTheme() {
+	if (!browser || typeof window.matchMedia !== 'function') {
+		return null;
+	}
+
+	return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+}
+
+function resolveStoredTheme(savedPreferences, storedTheme) {
+	if (VALID_THEMES.has(storedTheme)) {
+		return storedTheme;
+	}
+
+	if (savedPreferences && typeof savedPreferences === 'object') {
+		if (VALID_THEMES.has(savedPreferences.theme)) {
+			return savedPreferences.theme;
+		}
+
+		if (savedPreferences.darkMode === true) {
+			return 'dark';
+		}
+	}
+
+	const systemTheme = getSystemTheme();
+	if (systemTheme && VALID_THEMES.has(systemTheme)) {
+		return systemTheme;
+	}
+
+	return defaultPreferences.theme;
+}
+
 function loadInitialPreferences() {
 	if (!browser) return defaultPreferences;
+
 	try {
 		const saved = JSON.parse(localStorage.getItem(STORAGE_KEY) || 'null');
 		const storedTheme = localStorage.getItem(THEME_STORAGE_KEY);
 
-		if (saved && typeof saved === 'object') {
-			const inferredTheme =
-				storedTheme === 'dark' ? 'dark' : saved.theme || defaultPreferences.theme;
-			return {
-				...defaultPreferences,
-				...saved,
-				theme: inferredTheme,
-				darkMode: inferredTheme === 'dark'
-			};
-		}
+		const inferredTheme = resolveStoredTheme(saved, storedTheme);
+		const initialPreferences = {
+			...defaultPreferences,
+			...(saved && typeof saved === 'object' ? saved : {}),
+			theme: inferredTheme,
+			darkMode: inferredTheme === 'dark'
+		};
 
-		if (storedTheme === 'dark') {
-			return { ...defaultPreferences, darkMode: true, theme: 'dark' };
-		}
+		applyTheme(initialPreferences.theme);
+		return initialPreferences;
 	} catch (error) {
 		console.warn('Failed to parse stored preferences', error);
 	}
+
+	applyTheme(defaultPreferences.theme);
 	return defaultPreferences;
 }
 
 export const preferences = writable(loadInitialPreferences());
 
 preferences.subscribe((value) => {
-	if (browser) {
-		const theme = value?.theme === 'dark' || value?.darkMode ? 'dark' : 'light';
-		const nextPreferences = { ...value, theme, darkMode: theme === 'dark' };
-
-		localStorage.setItem(STORAGE_KEY, JSON.stringify(nextPreferences));
-		localStorage.setItem(THEME_STORAGE_KEY, theme);
-		document.documentElement.classList.toggle('dark', theme === 'dark');
+	if (!browser) {
+		return;
 	}
+
+	const theme = value?.theme === 'dark' || value?.darkMode ? 'dark' : 'light';
+	const nextPreferences = { ...defaultPreferences, ...value, theme, darkMode: theme === 'dark' };
+
+	localStorage.setItem(STORAGE_KEY, JSON.stringify(nextPreferences));
+	localStorage.setItem(THEME_STORAGE_KEY, theme);
+	applyTheme(theme);
 });
+
+export function toggleTheme() {
+	preferences.update((current) => {
+		const currentlyDark = current.theme === 'dark' || current.darkMode === true;
+		const nextTheme = currentlyDark ? 'light' : 'dark';
+
+		return {
+			...current,
+			theme: nextTheme,
+			darkMode: nextTheme === 'dark'
+		};
+	});
+}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -10,14 +10,12 @@
 		Upload,
 		Download
 	} from 'lucide-svelte';
-	import { onMount } from 'svelte';
 	import { get } from 'svelte/store';
 	import { goto } from '$app/navigation';
 	import { page } from '$app/stores';
-	import { browser } from '$app/environment';
 	import clsx from 'clsx';
 
-	import { preferences } from '$lib/preferencesStore.js';
+	import { preferences, toggleTheme } from '$lib/preferencesStore.js';
 	import { labs, normalizeLabsCollection } from '$lib/stores.js';
 
 	let filePicker;
@@ -28,26 +26,6 @@
 		{ href: '/writeups', label: 'Blog Mode', icon: NotebookPen }
 	];
 
-	onMount(() => {
-		if (browser) {
-			const storedTheme = localStorage.getItem('theme');
-			const currentPreferences = get(preferences);
-			const isDark = storedTheme
-				? storedTheme === 'dark'
-				: Boolean(currentPreferences.theme === 'dark' || currentPreferences.darkMode);
-
-			document.documentElement.classList.toggle('dark', isDark);
-
-			if (Boolean(currentPreferences.theme === 'dark') !== isDark) {
-				preferences.set({
-					...currentPreferences,
-					theme: isDark ? 'dark' : 'light',
-					darkMode: isDark
-				});
-			}
-		}
-	});
-
 	function resetData() {
 		if (confirm('Are you sure you want to reset all data?')) {
 			localStorage.removeItem('my-advanced-labs');
@@ -56,11 +34,7 @@
 	}
 
 	function toggleDarkMode() {
-		preferences.update((current) => {
-			const currentlyDark = current.theme === 'dark' || current.darkMode;
-			const nextTheme = currentlyDark ? 'light' : 'dark';
-			return { ...current, theme: nextTheme, darkMode: nextTheme === 'dark' };
-		});
+		toggleTheme();
 	}
 
 	function toggleExamPrepMode() {


### PR DESCRIPTION
## Summary
- update the pre-hydration theme script to sync the dark class, data-theme attribute, and color-scheme on both the html root and body
- have the preferences store applyTheme helper mirror those updates so the toggle reliably affects the full layout after hydration
- simplify the layout by relying on the central toggle helper instead of manually forcing document classes

## Testing
- npm run lint *(fails: Prettier violations in src/lib/data/pg_practice_labs.json and src/routes/stats/+page.svelte)*

------
https://chatgpt.com/codex/tasks/task_e_68d91d2790c08322b234c90768a7efa8