### PR TITLE
Fix dark mode background coverage

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -1,5 +1,20 @@
 @import 'tailwindcss';
 
+body {
+	margin: 0;
+	min-height: 100vh;
+	background-color: theme('colors.slate.50');
+	color: theme('colors.slate.800');
+	transition:
+		background-color 150ms ease,
+		color 150ms ease;
+}
+
+.dark body {
+	background-color: theme('colors.slate.950');
+	color: theme('colors.slate.100');
+}
+
 @layer components {
 	.note-screenshot {
 		@apply my-4 overflow-hidden rounded-2xl border border-slate-200 bg-slate-100 dark:border-slate-800 dark:bg-slate-900/50;


### PR DESCRIPTION
## Summary
- ensure the document body resets its margin and applies themed background/text colors
- update the dark theme body colors so the interface no longer shows white borders when toggled
- keep the existing component styles intact while adding smooth transitions for background and text

## Testing
- `npm run lint` *(fails: formatting issues remain in src/lib/data/pg_practice_labs.json and src/routes/stats/+page.svelte)*

------
https://chatgpt.com/codex/tasks/task_e_68d92d5efc2c8322a5bca8a9a3f7d094