### PR TITLE
Set dark theme as default preference

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -8,9 +8,13 @@
 			(() => {
 				try {
 					const storedTheme = localStorage.getItem('theme');
-					const prefersDark =
-						window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
-					const theme = storedTheme === 'dark' || (!storedTheme && prefersDark) ? 'dark' : 'light';
+					let theme = 'dark';
+
+					if (storedTheme === 'light') {
+						theme = 'light';
+					} else if (storedTheme === 'dark') {
+						theme = 'dark';
+					}
 					const root = document.documentElement;
 					root.classList.toggle('dark', theme === 'dark');
 					root.style.colorScheme = theme;

--- a/src/lib/preferencesStore.js
+++ b/src/lib/preferencesStore.js
@@ -6,8 +6,8 @@ const STORAGE_KEY = 'rootquest-preferences';
 const THEME_STORAGE_KEY = 'theme';
 
 const defaultPreferences = {
-	darkMode: false,
-	theme: 'light',
+	darkMode: true,
+	theme: 'dark',
 	examPrepMode: false
 };
 
@@ -54,7 +54,7 @@ function resolveStoredTheme(savedPreferences, storedTheme) {
 }
 
 function loadInitialPreferences() {
-	if (!browser) return defaultPreferences;
+	if (!browser) return { ...defaultPreferences };
 
 	try {
 		const saved = JSON.parse(localStorage.getItem(STORAGE_KEY) || 'null');
@@ -75,7 +75,7 @@ function loadInitialPreferences() {
 	}
 
 	applyTheme(defaultPreferences.theme);
-	return defaultPreferences;
+	return { ...defaultPreferences };
 }
 
 export const preferences = writable(loadInitialPreferences());


### PR DESCRIPTION
## Summary
- default the stored preferences to the dark theme and ensure fallback copies use the updated defaults
- update the inline theme bootstrapper to assume dark mode unless an explicit light theme was saved

## Testing
- npm run lint *(fails: reports existing formatting issues in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d934fe8af883229cf11af4bbacf81d