### PR TITLE
Fix light theme toggle with dark defaults

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -8,11 +8,16 @@
 			(() => {
 				try {
 					const storedTheme = localStorage.getItem('theme');
-					const prefersDark =
-						window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
-					const theme = storedTheme === 'dark' || (!storedTheme && prefersDark) ? 'dark' : 'light';
+					const theme = storedTheme === 'light' ? 'light' : 'dark';
 					const root = document.documentElement;
-					root.classList.toggle('dark', theme === 'dark');
+
+					if (theme === 'dark') {
+						root.classList.add('dark');
+					} else {
+						root.classList.remove('dark');
+					}
+
+					root.dataset.theme = theme;
 					root.style.colorScheme = theme;
 				} catch (error) {
 					console.warn('Unable to apply saved theme preference', error);

--- a/src/lib/preferencesStore.js
+++ b/src/lib/preferencesStore.js
@@ -6,8 +6,8 @@ const STORAGE_KEY = 'rootquest-preferences';
 const THEME_STORAGE_KEY = 'theme';
 
 const defaultPreferences = {
-	darkMode: false,
-	theme: 'light',
+	darkMode: true,
+	theme: 'dark',
 	examPrepMode: false
 };
 
@@ -18,16 +18,15 @@ function applyTheme(theme) {
 
 	const resolvedTheme = VALID_THEMES.has(theme) ? theme : defaultPreferences.theme;
 	const root = document.documentElement;
-	root.classList.toggle('dark', resolvedTheme === 'dark');
-	root.style.colorScheme = resolvedTheme;
-}
 
-function getSystemTheme() {
-	if (!browser || typeof window.matchMedia !== 'function') {
-		return null;
+	if (resolvedTheme === 'dark') {
+		root.classList.add('dark');
+	} else {
+		root.classList.remove('dark');
 	}
 
-	return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+	root.dataset.theme = resolvedTheme;
+	root.style.colorScheme = resolvedTheme;
 }
 
 function resolveStoredTheme(savedPreferences, storedTheme) {
@@ -43,18 +42,17 @@ function resolveStoredTheme(savedPreferences, storedTheme) {
 		if (savedPreferences.darkMode === true) {
 			return 'dark';
 		}
-	}
 
-	const systemTheme = getSystemTheme();
-	if (systemTheme && VALID_THEMES.has(systemTheme)) {
-		return systemTheme;
+		if (savedPreferences.darkMode === false) {
+			return 'light';
+		}
 	}
 
 	return defaultPreferences.theme;
 }
 
 function loadInitialPreferences() {
-	if (!browser) return defaultPreferences;
+	if (!browser) return { ...defaultPreferences };
 
 	try {
 		const saved = JSON.parse(localStorage.getItem(STORAGE_KEY) || 'null');
@@ -75,7 +73,7 @@ function loadInitialPreferences() {
 	}
 
 	applyTheme(defaultPreferences.theme);
-	return defaultPreferences;
+	return { ...defaultPreferences };
 }
 
 export const preferences = writable(loadInitialPreferences());


### PR DESCRIPTION
## Summary
- ensure the inline theme bootstrapper adds or removes the dark class explicitly and records the active theme
- update the preferences store to drive the document class in the same way, set a theme data attribute, and honor the dark default when no saved theme exists

## Testing
- npm run lint *(fails: formatting issues remain in src/lib/data/pg_practice_labs.json and src/routes/stats/+page.svelte)*

------
https://chatgpt.com/codex/tasks/task_e_68d934fe8af883229cf11af4bbacf81d