### PR TITLE
Improve lab OS selection and tweak dashboard styling

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -44,7 +44,7 @@ body {
 	}
 
 	.pill-counter {
-		@apply border border-cyan-400/20 text-xs font-semibold text-slate-200;
+		@apply rounded-full px-2 py-0.5 text-xs font-semibold text-slate-200;
 		background: linear-gradient(135deg, rgba(13, 27, 56, 0.88), rgba(7, 16, 34, 0.7));
 		box-shadow: 0 12px 28px rgba(6, 14, 32, 0.45);
 	}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -56,6 +56,18 @@
 	);
 
 	const initialData = { htb: htbData, pg: pgPracticeData, oscp: oscpData };
+	const osOptions = Array.from(
+		new Set(
+			Object.values(initialData || {}).flatMap(
+				(source) =>
+					source?.categories?.flatMap(
+						(category) => category?.labs?.map((lab) => lab?.os).filter(Boolean) || []
+					) || []
+			)
+		)
+	)
+		.filter(Boolean)
+		.sort((a, b) => a.localeCompare(b));
 
 	let activeListKey = 'htb';
 	let activeCategoryName = '';
@@ -66,7 +78,7 @@
 	let showAddForm = false;
 	let newLabName = '';
 	let newLabDifficulty = 'Easy';
-	let newLabOs = '';
+	let newLabOs = osOptions[0] || '';
 	let newLabServices = '';
 	let newLabTags = '';
 	let newLabCves = '';
@@ -286,7 +298,7 @@
 
 		newLabName = '';
 		newLabDifficulty = 'Easy';
-		newLabOs = '';
+		newLabOs = osOptions[0] || '';
 		newLabServices = '';
 		newLabTags = '';
 		newLabCves = '';
@@ -614,13 +626,15 @@
 										class="text-xs font-semibold tracking-[0.25em] text-slate-400 uppercase"
 										>OS</label
 									>
-									<input
+									<select
 										id="new-lab-os"
-										type="text"
-										placeholder="Linux / Windows / AD"
 										bind:value={newLabOs}
 										class="input-elevated w-full rounded-lg px-3 py-2 text-sm"
-									/>
+									>
+										{#each osOptions as option (option)}
+											<option value={option}>{option}</option>
+										{/each}
+									</select>
 								</div>
 							</div>
 							<div class="space-y-2">
@@ -718,7 +732,7 @@
 				<div class="grid grid-cols-3 gap-3 text-center">
 					{#each Object.entries(overallStatus) as [status, count] (status)}
 						<div class="glass-surface rounded-xl p-3">
-							<p class="text-xs font-semibold tracking-[0.25em] text-slate-400 uppercase">
+							<p class="text-[0.7rem] font-semibold tracking-[0.18em] text-slate-400 uppercase">
 								{STATUS_META[status].label}
 							</p>
 							<p class="text-2xl font-bold text-slate-100">{count}</p>


### PR DESCRIPTION
## Summary
- replace the quick-add OS text field with a dropdown populated from existing lab metadata
- restyle the category pill counters for a cleaner badge appearance
- tweak scoreboard label typography to keep status names within their cards

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d96fd109e083228aecab1c1676f781