### PR TITLE
Restrict quick add lab OS options to Linux and Windows

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -56,18 +56,7 @@
 	);
 
 	const initialData = { htb: htbData, pg: pgPracticeData, oscp: oscpData };
-	const osOptions = Array.from(
-		new Set(
-			Object.values(initialData || {}).flatMap(
-				(source) =>
-					source?.categories?.flatMap(
-						(category) => category?.labs?.map((lab) => lab?.os).filter(Boolean) || []
-					) || []
-			)
-		)
-	)
-		.filter(Boolean)
-		.sort((a, b) => a.localeCompare(b));
+        const osOptions = ['Linux', 'Windows'];
 
 	let activeListKey = 'htb';
 	let activeCategoryName = '';


### PR DESCRIPTION
## Summary
- limit the Quick Add Lab OS dropdown to only Linux and Windows options

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d97486996483229498efd78d845967