### PR TITLE
Update branding references to Hack Ascent HQ

### DIFF
--- a/src/lib/data/oscp_labs.json
+++ b/src/lib/data/oscp_labs.json
@@ -1,6 +1,6 @@
 {
 	"listName": "OSCP Labs",
-	"description": "Core PWK, ProLabs, and post-exam lab targets for Root Quest 2.0",
+        "description": "Core PWK, ProLabs, and post-exam lab targets for Hack Ascent HQ",
 	"categories": [
 		{
 			"name": "PWK Core",

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -114,8 +114,8 @@
 						class="absolute -bottom-20 -left-20 h-56 w-56 rounded-full bg-emerald-500/10 blur-3xl"
 					></div>
 				</div>
-				<h1 class="text-3xl font-bold tracking-tight text-slate-100">
-					<a href="/">🏆 Root Quest 2.0 🛡️</a>
+                                <h1 class="text-3xl font-bold tracking-tight text-slate-100">
+                                        <a href="/">🏆 Hack Ascent HQ 🛡️</a>
 				</h1>
 				<p class="mt-2 text-sm text-slate-300">
 					Track every Hack The Box, Proving Grounds, and OSCP lab with a hacker-grade dashboard.

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -507,7 +507,7 @@
 </script>
 
 <svelte:head>
-	<title>Root Quest 2.0 Dashboard</title>
+    <title>Hack Ascent HQ Dashboard</title>
 </svelte:head>
 
 <section class="space-y-6">

--- a/src/routes/stats/+page.svelte
+++ b/src/routes/stats/+page.svelte
@@ -149,7 +149,7 @@
 </script>
 
 <svelte:head>
-	<title>Root Quest 2.0 — Timeline & Graphs</title>
+        <title>Hack Ascent HQ — Timeline & Graphs</title>
 </svelte:head>
 
 <section class="space-y-8">

--- a/src/routes/writeups/+page.svelte
+++ b/src/routes/writeups/+page.svelte
@@ -33,7 +33,7 @@
 </script>
 
 <svelte:head>
-	<title>Root Quest 2.0 — Blog Mode</title>
+     <title>Hack Ascent HQ — Blog Mode</title>
 </svelte:head>
 
 <section class="space-y-6">

--- a/src/routes/writeups/[id]/+page.svelte
+++ b/src/routes/writeups/[id]/+page.svelte
@@ -103,7 +103,7 @@
 		if (!markdownWriteup) return;
 		const content =
 			format === 'html'
-				? `<!doctype html><html><head><meta charset="utf-8"><title>${lab.name} — Root Quest Writeup</title></head><body>${htmlWriteup}</body></html>`
+                            ? `<!doctype html><html><head><meta charset="utf-8"><title>${lab.name} — Hack Ascent HQ Writeup</title></head><body>${htmlWriteup}</body></html>`
 				: markdownWriteup;
 		const blob = new Blob([content], { type: format === 'html' ? 'text/html' : 'text/markdown' });
 		const url = URL.createObjectURL(blob);
@@ -123,7 +123,7 @@
 </script>
 
 <svelte:head>
-	<title>{lab ? `${lab.name} — Root Quest Blog Mode` : 'Writeup not found'}</title>
+    <title>{lab ? `${lab.name} — Hack Ascent HQ Blog Mode` : 'Writeup not found'}</title>
 </svelte:head>
 
 {#if !lab}


### PR DESCRIPTION
## Summary
- update the primary site heading and multiple page `<title>` tags to reference Hack Ascent HQ
- refresh OSCP lab data description to use the new Hack Ascent HQ name

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d983a7d47483229f86d2442e2ee7de