### PR TITLE
feat: refresh dark ui theme

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -4,3 +4,6 @@ pnpm-lock.yaml
 yarn.lock
 bun.lock
 bun.lockb
+
+# Large data files managed separately
+src/lib/data/*.json

--- a/src/app.css
+++ b/src/app.css
@@ -4,11 +4,11 @@ body {
 	margin: 0;
 	min-height: 100vh;
 	background:
-		radial-gradient(circle at 12% -18%, rgba(56, 189, 248, 0.22) 0%, rgba(2, 6, 23, 0) 46%),
-		radial-gradient(circle at 88% -10%, rgba(14, 165, 233, 0.16) 0%, rgba(2, 6, 23, 0) 52%),
-		radial-gradient(circle at 25% 72%, rgba(45, 212, 191, 0.12) 0%, rgba(2, 6, 23, 0) 48%),
-		linear-gradient(160deg, #020617 0%, #061634 42%, #020617 100%);
-	color: theme('colors.slate.100');
+		radial-gradient(circle at 12% -18%, rgba(168, 85, 247, 0.22) 0%, rgba(7, 2, 18, 0) 46%),
+		radial-gradient(circle at 88% -12%, rgba(236, 72, 153, 0.18) 0%, rgba(8, 3, 21, 0) 52%),
+		radial-gradient(circle at 25% 72%, rgba(129, 140, 248, 0.14) 0%, rgba(8, 3, 21, 0) 48%),
+		linear-gradient(160deg, #050012 0%, #12072a 42%, #050012 100%);
+	color: theme('colors.zinc.100');
 	-webkit-font-smoothing: antialiased;
 	text-rendering: optimizeLegibility;
 	transition:
@@ -18,40 +18,40 @@ body {
 
 .dark body {
 	background:
-		radial-gradient(circle at 5% -15%, rgba(56, 189, 248, 0.18) 0%, rgba(2, 6, 23, 0) 42%),
-		radial-gradient(circle at 92% -5%, rgba(16, 185, 129, 0.16) 0%, rgba(2, 6, 23, 0) 55%),
-		radial-gradient(circle at 30% 65%, rgba(14, 165, 233, 0.12) 0%, rgba(2, 6, 23, 0) 48%),
-		linear-gradient(175deg, #010417 0%, #04102a 48%, #010417 100%);
-	color: theme('colors.slate.100');
+		radial-gradient(circle at 5% -15%, rgba(192, 132, 252, 0.18) 0%, rgba(5, 0, 18, 0) 42%),
+		radial-gradient(circle at 92% -5%, rgba(217, 70, 239, 0.16) 0%, rgba(5, 0, 18, 0) 55%),
+		radial-gradient(circle at 30% 65%, rgba(129, 140, 248, 0.12) 0%, rgba(5, 0, 18, 0) 48%),
+		linear-gradient(175deg, #030015 0%, #0d0524 48%, #030015 100%);
+	color: theme('colors.zinc.100');
 }
 
 @layer components {
 	.glass-panel {
-		@apply border border-white/10 shadow-[0_35px_90px_rgba(8,18,45,0.55)] backdrop-blur-2xl;
-		background: linear-gradient(135deg, rgba(11, 25, 53, 0.9), rgba(7, 16, 34, 0.78));
-		border-color: rgba(148, 163, 184, 0.22);
+		@apply border border-white/10 shadow-[0_35px_90px_rgba(18,8,44,0.55)] backdrop-blur-2xl;
+		background: linear-gradient(135deg, rgba(32, 12, 58, 0.9), rgba(18, 6, 38, 0.78));
+		border-color: rgba(192, 132, 252, 0.22);
 	}
 
 	.glass-surface {
-		@apply border border-white/10 shadow-[0_20px_60px_rgba(7,16,38,0.52)] backdrop-blur-xl;
-		background: linear-gradient(140deg, rgba(10, 22, 45, 0.86), rgba(6, 15, 32, 0.72));
-		border-color: rgba(148, 163, 184, 0.18);
+		@apply border border-white/10 shadow-[0_20px_60px_rgba(17,7,41,0.52)] backdrop-blur-xl;
+		background: linear-gradient(140deg, rgba(26, 10, 54, 0.86), rgba(14, 5, 33, 0.72));
+		border-color: rgba(192, 132, 252, 0.16);
 	}
 
 	.input-elevated {
-		@apply border border-white/10 text-slate-100 shadow-[0_12px_32px_rgba(7,16,38,0.45)] placeholder:text-slate-500 focus:border-cyan-400 focus:ring-2 focus:ring-cyan-400/40 focus:outline-none;
-		background: linear-gradient(135deg, rgba(11, 25, 53, 0.82), rgba(6, 15, 32, 0.76));
+		@apply border border-white/10 text-slate-100 shadow-[0_12px_32px_rgba(17,7,41,0.45)] placeholder:text-slate-500 focus:border-fuchsia-400 focus:ring-2 focus:ring-fuchsia-400/40 focus:outline-none;
+		background: linear-gradient(135deg, rgba(32, 12, 58, 0.82), rgba(18, 6, 38, 0.76));
 	}
 
 	.pill-counter {
 		@apply rounded-full px-2 py-0.5 text-xs font-semibold text-slate-200;
-		background: linear-gradient(135deg, rgba(13, 27, 56, 0.88), rgba(7, 16, 34, 0.7));
-		box-shadow: 0 12px 28px rgba(6, 14, 32, 0.45);
+		background: linear-gradient(135deg, rgba(36, 13, 64, 0.88), rgba(18, 6, 38, 0.7));
+		box-shadow: 0 12px 28px rgba(20, 8, 44, 0.45);
 	}
 
 	.note-screenshot {
 		@apply my-4 overflow-hidden rounded-2xl border border-white/10;
-		background: linear-gradient(140deg, rgba(9, 20, 40, 0.92), rgba(6, 15, 32, 0.76));
+		background: linear-gradient(140deg, rgba(24, 9, 48, 0.92), rgba(16, 5, 35, 0.76));
 	}
 
 	.note-screenshot img {
@@ -60,7 +60,7 @@ body {
 
 	.note-code {
 		@apply rounded-xl p-4 text-sm text-slate-100 shadow-inner;
-		background: rgba(2, 6, 23, 0.8);
+		background: rgba(10, 4, 25, 0.85);
 	}
 
 	.note-list {

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -108,14 +108,14 @@
 			<div>
 				<div class="pointer-events-none absolute inset-0 -z-10 opacity-70">
 					<div
-						class="absolute -top-24 -right-24 h-64 w-64 rounded-full bg-cyan-500/20 blur-3xl"
+						class="absolute -top-24 -right-24 h-64 w-64 rounded-full bg-fuchsia-500/20 blur-3xl"
 					></div>
 					<div
-						class="absolute -bottom-20 -left-20 h-56 w-56 rounded-full bg-emerald-500/10 blur-3xl"
+						class="absolute -bottom-20 -left-20 h-56 w-56 rounded-full bg-violet-500/10 blur-3xl"
 					></div>
 				</div>
-                                <h1 class="text-3xl font-bold tracking-tight text-slate-100">
-                                        <a href="/"> Checkmate Labs </a>
+				<h1 class="text-3xl font-bold tracking-tight text-slate-100">
+					<a href="/"> Checkmate Labs </a>
 				</h1>
 				<p class="mt-2 text-sm text-slate-300">
 					Track every Hack The Box, Proving Grounds, and OSCP lab with a hacker-grade dashboard.
@@ -129,8 +129,8 @@
 							class={clsx(
 								'inline-flex items-center gap-2 rounded-xl border px-3 py-2 text-sm font-semibold backdrop-blur-sm transition-colors',
 								$page.url.pathname === nav.href
-									? 'border-cyan-400/70 bg-[rgba(12,78,125,0.35)] text-cyan-100 shadow-[0_20px_55px_rgba(8,145,178,0.45)]'
-									: 'border-transparent text-slate-300 hover:border-cyan-400/35 hover:bg-[rgba(8,19,38,0.65)] hover:text-cyan-100'
+									? 'border-fuchsia-400/70 bg-[rgba(74,23,116,0.35)] text-fuchsia-100 shadow-[0_20px_55px_rgba(217,70,239,0.45)]'
+									: 'border-transparent text-slate-300 hover:border-fuchsia-400/35 hover:bg-[rgba(19,8,48,0.65)] hover:text-fuchsia-100'
 							)}
 							on:click={() => navigateTo(nav.href)}
 							type="button"
@@ -144,7 +144,7 @@
 				<div class="flex flex-wrap items-center gap-2 md:ml-auto">
 					<button
 						on:click={toggleExamPrepMode}
-						class="rounded-xl border border-emerald-400/20 bg-[rgba(9,19,35,0.75)] px-3 py-2 text-xs font-semibold tracking-wide text-slate-200 uppercase transition-colors hover:border-emerald-400/45 hover:bg-[rgba(16,185,129,0.16)] hover:text-emerald-200"
+						class="rounded-xl border border-violet-400/20 bg-[rgba(20,8,40,0.75)] px-3 py-2 text-xs font-semibold tracking-wide text-slate-200 uppercase transition-colors hover:border-violet-400/45 hover:bg-[rgba(168,85,247,0.16)] hover:text-violet-200"
 						type="button"
 					>
 						Exam Prep Mode {#if $preferences.examPrepMode}ON ✅{:else}OFF ❌{/if}
@@ -152,7 +152,7 @@
 
 					<button
 						on:click={toggleDarkMode}
-						class="rounded-xl border border-cyan-400/20 bg-[rgba(9,19,35,0.75)] p-2 text-slate-200 transition-colors hover:border-cyan-400/50 hover:bg-[rgba(8,145,178,0.16)] hover:text-cyan-100"
+						class="rounded-xl border border-fuchsia-400/20 bg-[rgba(20,8,40,0.75)] p-2 text-slate-200 transition-colors hover:border-fuchsia-400/50 hover:bg-[rgba(217,70,239,0.16)] hover:text-fuchsia-100"
 						type="button"
 						aria-label="Toggle dark mode"
 					>
@@ -165,7 +165,7 @@
 
 					<button
 						on:click={exportBackup}
-						class="inline-flex items-center gap-2 rounded-xl border border-emerald-400/20 bg-[rgba(9,19,35,0.75)] px-3 py-2 text-slate-200 transition-colors hover:border-emerald-400/45 hover:bg-[rgba(16,185,129,0.14)] hover:text-emerald-200"
+						class="inline-flex items-center gap-2 rounded-xl border border-violet-400/20 bg-[rgba(20,8,40,0.75)] px-3 py-2 text-slate-200 transition-colors hover:border-violet-400/45 hover:bg-[rgba(168,85,247,0.14)] hover:text-violet-200"
 						type="button"
 					>
 						<Download size={16} /> Backup
@@ -173,7 +173,7 @@
 
 					<button
 						on:click={triggerImport}
-						class="inline-flex items-center gap-2 rounded-xl border border-sky-400/20 bg-[rgba(9,19,35,0.75)] px-3 py-2 text-slate-200 transition-colors hover:border-sky-400/45 hover:bg-[rgba(56,189,248,0.14)] hover:text-sky-200"
+						class="inline-flex items-center gap-2 rounded-xl border border-fuchsia-400/20 bg-[rgba(20,8,40,0.75)] px-3 py-2 text-slate-200 transition-colors hover:border-fuchsia-400/45 hover:bg-[rgba(217,70,239,0.14)] hover:text-fuchsia-200"
 						type="button"
 					>
 						<Upload size={16} /> Restore
@@ -197,9 +197,9 @@
 	</div>
 
 	<footer
-		class="mt-8 w-full border-t border-white/5 bg-[rgba(7,15,32,0.85)] py-4 text-center text-sm text-slate-400 backdrop-blur-xl"
+		class="mt-8 w-full border-t border-white/5 bg-[rgba(12,5,32,0.88)] py-4 text-center text-sm text-slate-400 backdrop-blur-xl"
 	>
-		<p>Powered by gudgusguz </p>
+		<p>Powered by gudgusguz</p>
 	</footer>
 
 	<input

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -32,8 +32,8 @@
 	const STATUS_META = {
 		owned: {
 			label: 'Owned',
-			badge: 'border border-emerald-400/60 bg-emerald-500/15 text-emerald-200',
-			pill: 'border border-emerald-400/70 bg-emerald-500/20 text-emerald-100',
+			badge: 'border border-violet-400/60 bg-violet-500/15 text-violet-200',
+			pill: 'border border-violet-400/70 bg-violet-500/20 text-violet-100',
 			icon: '✅'
 		},
 		in_progress: {
@@ -56,7 +56,7 @@
 	);
 
 	const initialData = { htb: htbData, pg: pgPracticeData, oscp: oscpData };
-        const osOptions = ['Linux', 'Windows'];
+	const osOptions = ['Linux', 'Windows'];
 
 	let activeListKey = 'htb';
 	let activeCategoryName = '';
@@ -507,7 +507,7 @@
 </script>
 
 <svelte:head>
-    <title>Hack Ascent HQ Dashboard</title>
+	<title>Hack Ascent HQ Dashboard</title>
 </svelte:head>
 
 <section class="space-y-6">
@@ -563,7 +563,7 @@
 					<h2 class="text-lg font-bold text-slate-100">Categories</h2>
 					<button
 						on:click={() => (showAddForm = !showAddForm)}
-						class="rounded-full border border-emerald-500/30 bg-emerald-500/10 p-2 text-emerald-300 transition-all hover:border-emerald-400/60 hover:bg-emerald-500/20 hover:text-emerald-200"
+						class="rounded-full border border-violet-500/30 bg-violet-500/10 p-2 text-violet-300 transition-all hover:border-violet-400/60 hover:bg-violet-500/20 hover:text-violet-200"
 						aria-label="Add lab"
 					>
 						<PlusCircle size={22} />
@@ -684,7 +684,7 @@
 							</div>
 							<button
 								type="submit"
-								class="w-full rounded-lg border border-emerald-500/50 bg-emerald-500/20 py-2 font-bold text-emerald-100 shadow-[0_12px_30px_rgba(16,185,129,0.35)] transition-colors hover:border-emerald-400/60 hover:bg-emerald-500/30"
+								class="w-full rounded-lg border border-violet-500/50 bg-violet-500/20 py-2 font-bold text-violet-100 shadow-[0_12px_30px_rgba(168,85,247,0.35)] transition-colors hover:border-violet-400/60 hover:bg-violet-500/30"
 							>
 								Add Lab
 							</button>
@@ -699,8 +699,8 @@
 							class={clsx(
 								'flex w-full items-center justify-between rounded-xl px-3 py-2 text-left text-sm font-semibold transition-colors',
 								activeCategoryName === category.name
-									? 'border border-emerald-400/60 bg-[rgba(16,185,129,0.18)] text-emerald-200 shadow-[0_18px_45px_rgba(16,185,129,0.4)]'
-									: 'border border-transparent text-slate-300 hover:border-emerald-400/30 hover:bg-[rgba(8,19,38,0.6)]'
+									? 'border border-violet-400/60 bg-[rgba(168,85,247,0.18)] text-violet-200 shadow-[0_18px_45px_rgba(168,85,247,0.4)]'
+									: 'border border-transparent text-slate-300 hover:border-violet-400/30 hover:bg-[rgba(19,8,48,0.6)]'
 							)}
 						>
 							<span>{category.name}</span>
@@ -718,20 +718,17 @@
 				<h2 class="flex items-center gap-2 text-lg font-bold text-slate-100">
 					<ShieldCheck size={18} /> Scoreboard
 				</h2>
-                                <div class="grid grid-cols-3 gap-3 text-center">
-                                        {#each Object.entries(overallStatus) as [status, count] (status)}
-                                                <div class="glass-surface rounded-xl p-3">
-                                                        <p
-                                                                class="mb-1 text-xl"
-                                                                aria-hidden="true"
-                                                        >
-                                                                {STATUS_META[status].icon}
-                                                        </p>
-                                                        <span class="sr-only">{STATUS_META[status].label}</span>
-                                                        <p class="text-2xl font-bold text-slate-100">{count}</p>
-                                                </div>
-                                        {/each}
-                                </div>
+				<div class="grid grid-cols-3 gap-3 text-center">
+					{#each Object.entries(overallStatus) as [status, count] (status)}
+						<div class="glass-surface rounded-xl p-3">
+							<p class="mb-1 text-xl" aria-hidden="true">
+								{STATUS_META[status].icon}
+							</p>
+							<span class="sr-only">{STATUS_META[status].label}</span>
+							<p class="text-2xl font-bold text-slate-100">{count}</p>
+						</div>
+					{/each}
+				</div>
 				<div class="space-y-3">
 					<h3 class="text-sm font-semibold tracking-[0.3em] text-slate-400 uppercase">
 						Owned by Category
@@ -747,17 +744,17 @@
 									class="h-2 overflow-hidden rounded-full border border-white/10 bg-[rgba(9,19,38,0.72)]"
 								>
 									<div
-										class="h-full bg-gradient-to-r from-emerald-400 via-emerald-500 to-teal-400 transition-all"
+										class="h-full bg-gradient-to-r from-fuchsia-400 via-violet-500 to-indigo-400 transition-all"
 										style={`width: ${category.total === 0 ? 0 : Math.min(100, (category.owned / category.total) * 100)}%;`}
 									></div>
 								</div>
-                                                                <p class="sr-only">
-                                                                        In progress: {category.inProgress}. Not started: {category.notStarted}.
-                                                                </p>
-                                                        </div>
-                                                {/each}
-                                        </div>
-                                </div>
+								<p class="sr-only">
+									In progress: {category.inProgress}. Not started: {category.notStarted}.
+								</p>
+							</div>
+						{/each}
+					</div>
+				</div>
 			</div>
 		</aside>
 
@@ -768,7 +765,7 @@
 						{#if currentlyPlayingLabs.length > 0}
 							<h3
 								id="currentlyPlayingHeading"
-								class="text-sm font-semibold tracking-wide text-emerald-500 uppercase"
+								class="text-sm font-semibold tracking-wide text-violet-500 uppercase"
 							>
 								Currently Playing
 							</h3>
@@ -776,7 +773,7 @@
 						{#if lastPlayedLab}
 							<h3
 								id="lastPlayedHeading"
-								class="text-sm font-semibold tracking-wide text-sky-500 uppercase md:text-right"
+								class="text-sm font-semibold tracking-wide text-indigo-500 uppercase md:text-right"
 							>
 								Last Played
 							</h3>
@@ -790,11 +787,11 @@
 						{#if currentlyPlayingLabs.length > 0}
 							{#each currentlyPlayingLabs as lab (lab.id)}
 								<article
-									class="flex flex-col gap-4 rounded-2xl border border-emerald-400/60 bg-gradient-to-br from-emerald-500/15 via-slate-900/70 to-slate-950/80 p-5 shadow-[0_35px_80px_rgba(16,185,129,0.35)] transition-shadow hover:shadow-[0_45px_100px_rgba(16,185,129,0.45)]"
+									class="flex flex-col gap-4 rounded-2xl border border-violet-400/60 bg-gradient-to-br from-violet-500/15 via-slate-900/70 to-slate-950/80 p-5 shadow-[0_35px_80px_rgba(168,85,247,0.35)] transition-shadow hover:shadow-[0_45px_100px_rgba(168,85,247,0.45)]"
 								>
 									<div class="flex items-start justify-between gap-4">
 										<div class="space-y-1">
-											<p class="text-xs font-semibold tracking-wide text-emerald-500 uppercase">
+											<p class="text-xs font-semibold tracking-wide text-violet-500 uppercase">
 												In Progress Spotlight
 											</p>
 											<h3 class="text-xl font-bold text-slate-100">
@@ -814,21 +811,21 @@
 									<div class="flex flex-wrap gap-2 text-xs text-slate-300/80">
 										{#if lab.difficulty}
 											<span
-												class="rounded-full border border-emerald-400/60 bg-emerald-500/10 px-2 py-0.5 font-semibold text-emerald-200"
+												class="rounded-full border border-violet-400/60 bg-violet-500/10 px-2 py-0.5 font-semibold text-violet-200"
 											>
 												{lab.difficulty}
 											</span>
 										{/if}
 										{#each lab.services || [] as service (service)}
 											<span
-												class="rounded-full border border-white/15 bg-[rgba(8,19,38,0.68)] px-2 py-0.5"
+												class="rounded-full border border-white/15 bg-[rgba(19,8,48,0.68)] px-2 py-0.5"
 											>
 												{service}
 											</span>
 										{/each}
 										{#each lab.cves || [] as cve (cve)}
 											<span
-												class="rounded-full border border-emerald-400/50 bg-emerald-500/10 px-2 py-0.5 text-emerald-200"
+												class="rounded-full border border-violet-400/50 bg-violet-500/10 px-2 py-0.5 text-violet-200"
 											>
 												{cve}
 											</span>
@@ -841,7 +838,7 @@
 										<div class="flex items-center gap-2">
 											<button
 												on:click={() => openNoteModal(lab)}
-												class="inline-flex items-center gap-2 rounded-lg border border-emerald-400/60 bg-emerald-500/10 px-3 py-1 text-xs font-semibold text-emerald-200 transition-colors hover:bg-emerald-500/20"
+												class="inline-flex items-center gap-2 rounded-lg border border-violet-400/60 bg-violet-500/10 px-3 py-1 text-xs font-semibold text-violet-200 transition-colors hover:bg-violet-500/20"
 											>
 												Notes
 											</button>
@@ -851,7 +848,7 @@
 														'rounded-lg border px-2 py-1 text-xs font-semibold transition-colors',
 														lab.status === statusKey
 															? `${meta.pill} border-transparent`
-															: 'border-white/15 bg-[rgba(8,19,38,0.6)] text-slate-300 hover:border-emerald-400/55 hover:bg-[rgba(16,185,129,0.15)] hover:text-emerald-200'
+															: 'border-white/15 bg-[rgba(19,8,48,0.6)] text-slate-300 hover:border-violet-400/55 hover:bg-[rgba(168,85,247,0.15)] hover:text-violet-200'
 													)}
 													on:click={() => setLabStatus(lab, statusKey)}
 													type="button"
@@ -868,11 +865,11 @@
 						{#if lastPlayedLab}
 							<article
 								aria-labelledby="lastPlayedHeading"
-								class="flex flex-col gap-4 rounded-2xl border border-sky-400/60 bg-gradient-to-br from-sky-500/15 via-slate-900/70 to-slate-950/80 p-5 shadow-[0_35px_80px_rgba(56,189,248,0.35)] transition-shadow hover:shadow-[0_45px_100px_rgba(56,189,248,0.45)]"
+								class="flex flex-col gap-4 rounded-2xl border border-indigo-400/60 bg-gradient-to-br from-indigo-500/15 via-slate-900/70 to-slate-950/80 p-5 shadow-[0_35px_80px_rgba(192,132,252,0.35)] transition-shadow hover:shadow-[0_45px_100px_rgba(192,132,252,0.45)]"
 							>
 								<div class="flex items-start justify-between gap-4">
 									<div class="space-y-1">
-										<p class="text-xs font-semibold tracking-wide text-sky-500 uppercase">
+										<p class="text-xs font-semibold tracking-wide text-indigo-500 uppercase">
 											Highlight
 										</p>
 										<h3 class="text-xl font-bold text-slate-100">
@@ -892,20 +889,20 @@
 								<div class="flex flex-wrap gap-2 text-xs text-slate-300/80">
 									{#if lastPlayedLab.difficulty}
 										<span
-											class="rounded-full border border-sky-400/60 bg-sky-500/10 px-2 py-0.5 font-semibold text-sky-200"
+											class="rounded-full border border-indigo-400/60 bg-indigo-500/10 px-2 py-0.5 font-semibold text-indigo-200"
 										>
 											{lastPlayedLab.difficulty}
 										</span>
 									{/if}
 									{#each lastPlayedLab.services || [] as service (service)}
 										<span
-											class="rounded-full border border-white/15 bg-[rgba(8,19,38,0.68)] px-2 py-0.5"
+											class="rounded-full border border-white/15 bg-[rgba(19,8,48,0.68)] px-2 py-0.5"
 											>{service}</span
 										>
 									{/each}
 									{#each lastPlayedLab.cves || [] as cve (cve)}
 										<span
-											class="rounded-full border border-sky-400/50 bg-sky-500/10 px-2 py-0.5 text-sky-200"
+											class="rounded-full border border-indigo-400/50 bg-indigo-500/10 px-2 py-0.5 text-indigo-200"
 										>
 											{cve}
 										</span>
@@ -920,13 +917,13 @@
 											href={buildLabUrl(lastPlayedLab)}
 											target="_blank"
 											rel="noopener noreferrer"
-											class="inline-flex items-center gap-2 rounded-lg border border-sky-400/60 bg-[rgba(8,19,38,0.65)] px-3 py-1 text-xs font-semibold text-sky-200 transition-colors hover:bg-[rgba(56,189,248,0.18)]"
+											class="inline-flex items-center gap-2 rounded-lg border border-indigo-400/60 bg-[rgba(19,8,48,0.65)] px-3 py-1 text-xs font-semibold text-indigo-200 transition-colors hover:bg-[rgba(192,132,252,0.18)]"
 										>
 											Open Lab
 										</a>
 										<button
 											on:click={() => openNoteModal(lastPlayedLab)}
-											class="inline-flex items-center gap-2 rounded-lg border border-sky-400/60 bg-[rgba(8,19,38,0.65)] px-3 py-1 text-xs font-semibold text-sky-200 transition-colors hover:bg-[rgba(56,189,248,0.18)]"
+											class="inline-flex items-center gap-2 rounded-lg border border-indigo-400/60 bg-[rgba(19,8,48,0.65)] px-3 py-1 text-xs font-semibold text-indigo-200 transition-colors hover:bg-[rgba(192,132,252,0.18)]"
 										>
 											Notes
 										</button>
@@ -936,7 +933,7 @@
 													'rounded-lg border px-2 py-1 text-xs font-semibold transition-colors',
 													lastPlayedLab.status === statusKey
 														? `${meta.pill} border-transparent`
-														: 'border-white/15 bg-[rgba(8,19,38,0.6)] text-slate-300 hover:border-sky-400/55 hover:bg-[rgba(56,189,248,0.16)] hover:text-sky-200'
+														: 'border-white/15 bg-[rgba(19,8,48,0.6)] text-slate-300 hover:border-indigo-400/55 hover:bg-[rgba(192,132,252,0.16)] hover:text-indigo-200'
 												)}
 												on:click={() => setLabStatus(lastPlayedLab, statusKey)}
 												type="button"
@@ -967,7 +964,7 @@
 
 			{#if labsToShow.length === 0}
 				<div
-					class="glass-surface border border-dashed border-cyan-400/25 p-6 text-center text-slate-300"
+					class="glass-surface border border-dashed border-fuchsia-400/25 p-6 text-center text-slate-300"
 				>
 					No labs matched your search.
 				</div>
@@ -976,9 +973,9 @@
 					{#each labsToShow as lab (lab.id)}
 						<article
 							class={clsx(
-								'group glass-surface flex flex-col overflow-hidden rounded-2xl transition-all hover:-translate-y-1 hover:shadow-[0_35px_100px_rgba(56,189,248,0.38)]',
+								'group glass-surface flex flex-col overflow-hidden rounded-2xl transition-all hover:-translate-y-1 hover:shadow-[0_35px_100px_rgba(192,132,252,0.38)]',
 								lab.status === 'owned'
-									? 'border-emerald-400/60 shadow-[0_35px_100px_rgba(16,185,129,0.38)]'
+									? 'border-violet-400/60 shadow-[0_35px_100px_rgba(168,85,247,0.38)]'
 									: ''
 							)}
 						>
@@ -987,9 +984,9 @@
 									class="glass-surface flex h-16 w-16 items-center justify-center overflow-hidden rounded-xl shadow-[0_18px_40px_rgba(7,16,38,0.5)]"
 								>
 									{#if labAvatar(lab) === 'linux'}
-										<Bird size={42} class="text-emerald-400/70" />
+										<Bird size={42} class="text-violet-400/70" />
 									{:else if labAvatar(lab) === 'windows'}
-										<Computer size={42} class="text-sky-400/70" />
+										<Computer size={42} class="text-indigo-400/70" />
 									{:else if labAvatar(lab) === 'ad'}
 										<Bot size={42} class="text-violet-400/70" />
 									{:else if lab.avatar}
@@ -1011,7 +1008,7 @@
 											class={clsx(
 												'rounded-full border px-2 py-1 text-xs font-bold',
 												lab.difficulty?.toLowerCase().includes('easy')
-													? 'border-emerald-400/60 bg-emerald-500/10 text-emerald-200'
+													? 'border-violet-400/60 bg-violet-500/10 text-violet-200'
 													: lab.difficulty?.toLowerCase().includes('hard')
 														? 'border-rose-400/60 bg-rose-500/10 text-rose-200'
 														: 'border-amber-400/60 bg-amber-500/10 text-amber-200'
@@ -1026,7 +1023,7 @@
 									<div class="mt-2 flex flex-wrap gap-2 text-xs text-slate-300/70">
 										{#each lab.services || [] as service (service)}
 											<span
-												class="rounded-full border border-white/15 bg-[rgba(8,19,38,0.68)] px-2 py-0.5"
+												class="rounded-full border border-white/15 bg-[rgba(19,8,48,0.68)] px-2 py-0.5"
 												>{service}</span
 											>
 										{/each}
@@ -1059,7 +1056,7 @@
 											href={buildLabUrl(lab)}
 											target="_blank"
 											rel="noopener noreferrer"
-											class="rounded-full border border-sky-400/30 bg-[rgba(8,19,38,0.65)] p-2 text-slate-200 transition-colors hover:border-sky-400/55 hover:bg-[rgba(56,189,248,0.18)] hover:text-sky-200"
+											class="rounded-full border border-indigo-400/30 bg-[rgba(19,8,48,0.65)] p-2 text-slate-200 transition-colors hover:border-indigo-400/55 hover:bg-[rgba(192,132,252,0.18)] hover:text-indigo-200"
 											title="Open lab portal"
 										>
 											<ExternalLink size={18} />
@@ -1069,8 +1066,8 @@
 											class={clsx(
 												'rounded-full border p-2 transition-colors',
 												(lab.notes || []).length > 0
-													? 'border-emerald-400/60 bg-emerald-500/10 text-emerald-200 hover:bg-emerald-500/20'
-													: 'border-white/15 bg-[rgba(8,19,38,0.6)] text-slate-300 hover:border-emerald-400/55 hover:bg-[rgba(16,185,129,0.14)] hover:text-emerald-200'
+													? 'border-violet-400/60 bg-violet-500/10 text-violet-200 hover:bg-violet-500/20'
+													: 'border-white/15 bg-[rgba(19,8,48,0.6)] text-slate-300 hover:border-violet-400/55 hover:bg-[rgba(168,85,247,0.14)] hover:text-violet-200'
 											)}
 											title={(lab.notes || []).length > 0 ? 'Manage notes' : 'Add notes'}
 										>
@@ -1078,7 +1075,7 @@
 										</button>
 										<a
 											href={`/writeups/${lab.id}`}
-											class="rounded-full border border-emerald-400/30 bg-[rgba(8,19,38,0.65)] p-2 text-slate-200 transition-colors hover:border-emerald-400/55 hover:bg-[rgba(16,185,129,0.16)] hover:text-emerald-200"
+											class="rounded-full border border-violet-400/30 bg-[rgba(19,8,48,0.65)] p-2 text-slate-200 transition-colors hover:border-violet-400/55 hover:bg-[rgba(168,85,247,0.16)] hover:text-violet-200"
 											title="Open blog mode"
 										>
 											<ShieldCheck size={18} />
@@ -1091,7 +1088,7 @@
 													'rounded-lg border px-2 py-1 text-xs font-semibold transition-colors',
 													lab.status === statusKey
 														? `${meta.pill} border-transparent`
-														: 'border-white/15 bg-[rgba(8,19,38,0.6)] text-slate-300 hover:border-emerald-400/55 hover:bg-[rgba(16,185,129,0.15)] hover:text-emerald-200'
+														: 'border-white/15 bg-[rgba(19,8,48,0.6)] text-slate-300 hover:border-violet-400/55 hover:bg-[rgba(168,85,247,0.15)] hover:text-violet-200'
 												)}
 												on:click={() => setLabStatus(lab, statusKey)}
 												type="button"
@@ -1144,7 +1141,7 @@
 								<div class="flex items-center gap-2">
 									<button
 										on:click={() => startEditIndividualNote(note)}
-										class="rounded-full border border-emerald-400/60 bg-emerald-500/10 p-2 text-emerald-200 transition-colors hover:bg-emerald-500/20"
+										class="rounded-full border border-violet-400/60 bg-violet-500/10 p-2 text-violet-200 transition-colors hover:bg-violet-500/20"
 										title="Edit note"
 									>
 										<Edit2 size={16} />
@@ -1170,20 +1167,20 @@
 								<div class="flex justify-end gap-2">
 									<button
 										on:click={saveIndividualNote}
-										class="inline-flex items-center gap-2 rounded-lg border border-emerald-400/60 bg-emerald-500/20 px-3 py-2 text-sm font-semibold text-emerald-100 shadow-[0_12px_30px_rgba(16,185,129,0.35)] transition-colors hover:bg-emerald-500/30"
+										class="inline-flex items-center gap-2 rounded-lg border border-violet-400/60 bg-violet-500/20 px-3 py-2 text-sm font-semibold text-violet-100 shadow-[0_12px_30px_rgba(168,85,247,0.35)] transition-colors hover:bg-violet-500/30"
 									>
 										<Save size={16} /> Save
 									</button>
 									<button
 										on:click={cancelEditIndividualNote}
-										class="inline-flex items-center gap-2 rounded-lg border border-white/15 bg-[rgba(8,19,38,0.65)] px-3 py-2 text-sm font-semibold text-slate-300 transition-colors hover:border-slate-400/50 hover:bg-[rgba(15,23,42,0.75)]"
+										class="inline-flex items-center gap-2 rounded-lg border border-white/15 bg-[rgba(19,8,48,0.65)] px-3 py-2 text-sm font-semibold text-slate-300 transition-colors hover:border-slate-400/50 hover:bg-[rgba(15,23,42,0.75)]"
 									>
 										<X size={16} /> Cancel
 									</button>
 								</div>
 							{:else}
 								<div
-									class="prose prose-sm dark:prose-invert prose-pre:bg-slate-900 prose-pre:text-slate-100 prose-code:text-emerald-500 max-w-none"
+									class="prose prose-sm dark:prose-invert prose-pre:bg-slate-900 prose-pre:text-slate-100 prose-code:text-violet-500 max-w-none"
 								>
 									<!-- eslint-disable-next-line svelte/no-at-html-tags -->
 									{@html renderNote(note)}
@@ -1219,7 +1216,7 @@
 					</span>
 					<button
 						on:click={addIndividualNote}
-						class="inline-flex items-center gap-2 rounded-lg border border-emerald-400/60 bg-emerald-500/20 px-4 py-2 text-sm font-semibold text-emerald-100 shadow-[0_12px_30px_rgba(16,185,129,0.35)] transition-colors hover:bg-emerald-500/30"
+						class="inline-flex items-center gap-2 rounded-lg border border-violet-400/60 bg-violet-500/20 px-4 py-2 text-sm font-semibold text-violet-100 shadow-[0_12px_30px_rgba(168,85,247,0.35)] transition-colors hover:bg-violet-500/30"
 					>
 						<Plus size={16} /> Add Note
 					</button>

--- a/src/routes/stats/+page.svelte
+++ b/src/routes/stats/+page.svelte
@@ -239,7 +239,9 @@
 		<section
 			class="grid gap-3 rounded-3xl border border-slate-700/30 bg-slate-900/60 p-5 shadow-lg backdrop-blur"
 		>
-			<div class="flex items-center gap-2 text-sm font-medium tracking-wide text-sky-300 uppercase">
+			<div
+				class="flex items-center gap-2 text-sm font-medium tracking-wide text-indigo-300 uppercase"
+			>
 				<Sparkles class="h-4 w-4" /> Signal Boost
 			</div>
 			<div class="grid gap-4 sm:grid-cols-3">
@@ -280,11 +282,11 @@
 	{#if uniqueDays.length}
 		<section class="glass-surface date-selector">
 			<div class="date-selector__header">
-				<Activity size={18} class="text-sky-400" />
+				<Activity size={18} class="text-indigo-400" />
 				<span>Pulse by Day</span>
 			</div>
 			<div class="date-selector__chips">
-				{#each uniqueDays.slice(0, 6) as day}
+				{#each uniqueDays.slice(0, 6) as day (day)}
 					<button
 						type="button"
 						class:active={day === selectedDate}
@@ -319,7 +321,7 @@
 
 	{#if timelineEvents.length === 0}
 		<div
-			class="glass-surface border border-dashed border-sky-400/25 p-10 text-center text-slate-300"
+			class="glass-surface border border-dashed border-indigo-400/25 p-10 text-center text-slate-300"
 		>
 			No events captured yet. Update statuses or add notes from the dashboard to populate this view.
 		</div>
@@ -461,7 +463,7 @@
 {#if focusedEvent}
 	<section class="glass-surface focus-panel space-y-4 rounded-3xl p-6">
 		<header class="flex items-center gap-3">
-			<NotebookPen size={24} class="text-emerald-400" />
+			<NotebookPen size={24} class="text-violet-400" />
 			<div>
 				<h3 class="text-xl font-semibold text-slate-100">
 					{focusedEvent.labName}
@@ -487,18 +489,18 @@
 		overflow: hidden;
 		border-radius: 2rem;
 		padding: clamp(1.75rem, 4vw, 3rem);
-		border: 1px solid rgba(56, 189, 248, 0.25);
-		background: linear-gradient(135deg, rgba(15, 23, 42, 0.95), rgba(2, 132, 199, 0.25));
-		box-shadow: 0 25px 55px rgba(8, 47, 73, 0.65);
+		border: 1px solid rgba(217, 70, 239, 0.35);
+		background: linear-gradient(135deg, rgba(32, 12, 58, 0.95), rgba(126, 34, 206, 0.35));
+		box-shadow: 0 25px 55px rgba(74, 23, 116, 0.6);
 	}
 
 	.hero-backdrop {
 		position: absolute;
 		inset: -20% -10%;
 		background:
-			radial-gradient(circle at 20% 15%, rgba(56, 189, 248, 0.3), transparent 55%),
-			radial-gradient(circle at 75% 40%, rgba(129, 140, 248, 0.25), transparent 60%),
-			radial-gradient(circle at 50% 90%, rgba(16, 185, 129, 0.35), transparent 65%);
+			radial-gradient(circle at 20% 15%, rgba(217, 70, 239, 0.35), transparent 55%),
+			radial-gradient(circle at 75% 40%, rgba(129, 140, 248, 0.3), transparent 60%),
+			radial-gradient(circle at 50% 90%, rgba(236, 72, 153, 0.32), transparent 65%);
 		filter: blur(20px);
 		opacity: 0.8;
 	}
@@ -527,17 +529,17 @@
 		width: 3.25rem;
 		height: 3.25rem;
 		border-radius: 1rem;
-		background: rgba(14, 165, 233, 0.2);
-		border: 1px solid rgba(56, 189, 248, 0.45);
-		color: rgb(224, 242, 254);
-		box-shadow: 0 10px 30px rgba(14, 165, 233, 0.35);
+		background: rgba(168, 85, 247, 0.22);
+		border: 1px solid rgba(217, 70, 239, 0.45);
+		color: rgb(250, 245, 255);
+		box-shadow: 0 10px 30px rgba(168, 85, 247, 0.35);
 	}
 
 	.hero-eyebrow {
 		font-size: 0.8rem;
 		letter-spacing: 0.25em;
 		text-transform: uppercase;
-		color: rgba(165, 243, 252, 0.85);
+		color: rgba(244, 114, 182, 0.85);
 		margin-bottom: 0.45rem;
 	}
 
@@ -566,10 +568,10 @@
 		align-items: center;
 		gap: 0.5rem;
 		border-radius: 9999px;
-		border: 1px solid rgba(16, 185, 129, 0.5);
-		background: linear-gradient(120deg, rgba(16, 185, 129, 0.28), rgba(14, 165, 233, 0.18));
+		border: 1px solid rgba(217, 70, 239, 0.5);
+		background: linear-gradient(120deg, rgba(217, 70, 239, 0.32), rgba(168, 85, 247, 0.25));
 		padding: 0.35rem 0.9rem;
-		color: rgb(209, 250, 229);
+		color: rgb(250, 245, 255);
 		font-size: 0.8rem;
 		letter-spacing: 0.05em;
 	}
@@ -577,17 +579,17 @@
 	.metric-tile {
 		position: relative;
 		border-radius: 1rem;
-		border: 1px solid rgba(45, 212, 191, 0.2);
-		background: linear-gradient(180deg, rgba(13, 148, 136, 0.18), rgba(2, 6, 23, 0.65));
+		border: 1px solid rgba(192, 132, 252, 0.25);
+		background: linear-gradient(180deg, rgba(126, 34, 206, 0.2), rgba(12, 5, 32, 0.7));
 		padding: 1.15rem;
-		box-shadow: inset 0 1px 0 rgba(45, 212, 191, 0.25);
+		box-shadow: inset 0 1px 0 rgba(192, 132, 252, 0.25);
 	}
 
 	.metric-label {
 		font-size: 0.75rem;
 		letter-spacing: 0.16em;
 		text-transform: uppercase;
-		color: rgba(204, 251, 241, 0.8);
+		color: rgba(221, 214, 254, 0.85);
 	}
 
 	.metric-value {
@@ -596,7 +598,7 @@
 		font-size: 1.875rem;
 		font-weight: 600;
 		color: rgb(226, 232, 240);
-		text-shadow: 0 8px 20px rgba(13, 148, 136, 0.35);
+		text-shadow: 0 8px 20px rgba(126, 34, 206, 0.35);
 	}
 
 	.legend-item {
@@ -605,22 +607,22 @@
 		gap: 0.5rem;
 		border-radius: 9999px;
 		border: 1px solid rgba(51, 65, 85, 0.4);
-		background: rgba(2, 6, 23, 0.6);
+		background: rgba(12, 5, 32, 0.65);
 		padding: 0.25rem 0.75rem;
-		box-shadow: 0 8px 18px rgba(15, 23, 42, 0.35);
+		box-shadow: 0 8px 18px rgba(32, 12, 58, 0.4);
 	}
 
 	.legend-dot {
 		width: 0.5rem;
 		height: 0.5rem;
 		border-radius: 9999px;
-		background: var(--color, #38bdf8);
-		box-shadow: 0 0 14px rgba(56, 189, 248, 0.55);
+		background: var(--color, #d946ef);
+		box-shadow: 0 0 14px rgba(217, 70, 239, 0.55);
 	}
 
 	.legend-dot.note {
-		background: linear-gradient(135deg, #38bdf8, #60a5fa);
-		box-shadow: 0 0 14px rgba(96, 165, 250, 0.8);
+		background: linear-gradient(135deg, #d946ef, #c084fc);
+		box-shadow: 0 0 14px rgba(192, 132, 252, 0.75);
 	}
 
 	.date-selector {
@@ -639,7 +641,7 @@
 		font-size: 0.85rem;
 		letter-spacing: 0.08em;
 		text-transform: uppercase;
-		color: rgba(125, 211, 252, 0.85);
+		color: rgba(244, 114, 182, 0.85);
 	}
 
 	.date-selector__chips {
@@ -659,15 +661,15 @@
 	}
 
 	.date-selector button:hover {
-		border-color: rgba(56, 189, 248, 0.55);
-		color: rgb(224, 242, 254);
+		border-color: rgba(217, 70, 239, 0.55);
+		color: rgb(250, 245, 255);
 	}
 
 	.date-selector button.active {
-		border-color: rgba(16, 185, 129, 0.8);
-		background: rgba(16, 185, 129, 0.2);
-		color: rgb(209, 250, 229);
-		box-shadow: 0 8px 22px rgba(16, 185, 129, 0.35);
+		border-color: rgba(217, 70, 239, 0.8);
+		background: rgba(217, 70, 239, 0.2);
+		color: rgb(250, 245, 255);
+		box-shadow: 0 8px 22px rgba(217, 70, 239, 0.35);
 	}
 
 	.date-selector__more {
@@ -689,10 +691,10 @@
 		width: 100%;
 		overflow-x: auto;
 		border-radius: 1.75rem;
-		border: 1px solid rgba(56, 189, 248, 0.25);
-		background: rgba(2, 6, 23, 0.7);
+		border: 1px solid rgba(217, 70, 239, 0.35);
+		background: rgba(12, 5, 32, 0.75);
 		padding: 1.25rem;
-		box-shadow: 0 28px 60px rgba(8, 47, 73, 0.65);
+		box-shadow: 0 28px 60px rgba(74, 23, 116, 0.55);
 		backdrop-filter: blur(18px);
 	}
 
@@ -701,9 +703,9 @@
 		inset: 0;
 		border-radius: 1.75rem;
 		background:
-			radial-gradient(circle at 15% 20%, rgba(14, 165, 233, 0.35), transparent 55%),
-			radial-gradient(circle at 80% 30%, rgba(96, 165, 250, 0.25), transparent 50%),
-			radial-gradient(circle at 50% 90%, rgba(16, 185, 129, 0.25), transparent 55%);
+			radial-gradient(circle at 15% 20%, rgba(217, 70, 239, 0.32), transparent 55%),
+			radial-gradient(circle at 80% 30%, rgba(129, 140, 248, 0.25), transparent 50%),
+			radial-gradient(circle at 50% 90%, rgba(236, 72, 153, 0.25), transparent 55%);
 		pointer-events: none;
 	}
 
@@ -735,13 +737,13 @@
 	}
 
 	.event-icon-wrapper img.focused {
-		outline: 2px solid rgba(52, 211, 153, 0.8);
+		outline: 2px solid rgba(217, 70, 239, 0.8);
 	}
 
 	.focus-panel {
-		border: 1px solid rgba(52, 211, 153, 0.25);
-		background: linear-gradient(160deg, rgba(15, 118, 110, 0.22), rgba(15, 23, 42, 0.75));
-		box-shadow: 0 25px 55px rgba(6, 95, 70, 0.45);
+		border: 1px solid rgba(217, 70, 239, 0.28);
+		background: linear-gradient(160deg, rgba(126, 34, 206, 0.22), rgba(15, 23, 42, 0.75));
+		box-shadow: 0 25px 55px rgba(74, 23, 116, 0.45);
 	}
 
 	@media (max-width: 720px) {

--- a/src/routes/writeups/+page.svelte
+++ b/src/routes/writeups/+page.svelte
@@ -33,7 +33,7 @@
 </script>
 
 <svelte:head>
-     <title>Hack Ascent HQ — Blog Mode</title>
+	<title>Hack Ascent HQ — Blog Mode</title>
 </svelte:head>
 
 <section class="space-y-6">
@@ -66,7 +66,7 @@
 	<div class="grid grid-cols-1 gap-5 md:grid-cols-2">
 		{#each $labs.filter(matches) as lab (lab.id)}
 			<article
-				class="glass-surface space-y-3 rounded-2xl p-5 transition-all hover:-translate-y-1 hover:border-emerald-400/60 hover:shadow-[0_30px_90px_rgba(16,185,129,0.4)]"
+				class="glass-surface space-y-3 rounded-2xl p-5 transition-all hover:-translate-y-1 hover:border-violet-400/60 hover:shadow-[0_30px_90px_rgba(168,85,247,0.4)]"
 			>
 				<header class="flex items-start justify-between gap-4">
 					<div>
@@ -74,7 +74,7 @@
 						<p class="text-sm text-slate-300/80">{lab.category} • {lab.os}</p>
 					</div>
 					<span
-						class="inline-flex items-center gap-2 rounded-full border border-emerald-400/60 bg-emerald-500/10 px-2 py-1 text-xs font-semibold text-emerald-200"
+						class="inline-flex items-center gap-2 rounded-full border border-violet-400/60 bg-violet-500/10 px-2 py-1 text-xs font-semibold text-violet-200"
 					>
 						<PenLine size={14} />
 						{(lab.notes || []).length} notes
@@ -82,7 +82,7 @@
 				</header>
 				{#if lab.notes?.length}
 					<div
-						class="prose prose-sm prose-invert prose-pre:bg-slate-950 prose-pre:text-slate-100 prose-code:text-emerald-400 max-h-32 max-w-none overflow-hidden"
+						class="prose prose-sm prose-invert prose-pre:bg-slate-950 prose-pre:text-slate-100 prose-code:text-violet-400 max-h-32 max-w-none overflow-hidden"
 					>
 						<!-- eslint-disable-next-line svelte/no-at-html-tags -->
 						{@html notePreview(lab)}
@@ -94,7 +94,7 @@
 				{/if}
 				<footer class="flex justify-end">
 					<a
-						class="inline-flex items-center gap-2 rounded-xl border border-emerald-400/60 bg-emerald-500/10 px-3 py-2 text-sm font-semibold text-emerald-200 transition-colors hover:bg-emerald-500/20"
+						class="inline-flex items-center gap-2 rounded-xl border border-violet-400/60 bg-violet-500/10 px-3 py-2 text-sm font-semibold text-violet-200 transition-colors hover:bg-violet-500/20"
 						href={`/writeups/${lab.id}`}
 					>
 						Open writeup <ArrowUpRight size={16} />

--- a/src/routes/writeups/[id]/+page.svelte
+++ b/src/routes/writeups/[id]/+page.svelte
@@ -103,7 +103,7 @@
 		if (!markdownWriteup) return;
 		const content =
 			format === 'html'
-                            ? `<!doctype html><html><head><meta charset="utf-8"><title>${lab.name} — Hack Ascent HQ Writeup</title></head><body>${htmlWriteup}</body></html>`
+				? `<!doctype html><html><head><meta charset="utf-8"><title>${lab.name} — Hack Ascent HQ Writeup</title></head><body>${htmlWriteup}</body></html>`
 				: markdownWriteup;
 		const blob = new Blob([content], { type: format === 'html' ? 'text/html' : 'text/markdown' });
 		const url = URL.createObjectURL(blob);
@@ -123,7 +123,7 @@
 </script>
 
 <svelte:head>
-    <title>{lab ? `${lab.name} — Hack Ascent HQ Blog Mode` : 'Writeup not found'}</title>
+	<title>{lab ? `${lab.name} — Hack Ascent HQ Blog Mode` : 'Writeup not found'}</title>
 </svelte:head>
 
 {#if !lab}
@@ -135,7 +135,7 @@
 		<header class="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
 			<div>
 				<button
-					class="inline-flex items-center gap-2 text-sm font-semibold text-emerald-200 transition-colors hover:text-emerald-100"
+					class="inline-flex items-center gap-2 text-sm font-semibold text-violet-200 transition-colors hover:text-violet-100"
 					on:click={() => goto('/writeups')}
 				>
 					<ArrowLeft size={16} /> Back to list
@@ -147,7 +147,7 @@
 			</div>
 			<div class="flex flex-wrap gap-2">
 				<button
-					class="inline-flex items-center gap-2 rounded-xl border border-emerald-400/30 bg-[rgba(8,19,38,0.65)] px-3 py-2 text-slate-200 transition-colors hover:border-emerald-400/55 hover:bg-[rgba(16,185,129,0.16)] hover:text-emerald-200"
+					class="inline-flex items-center gap-2 rounded-xl border border-violet-400/30 bg-[rgba(19,8,48,0.65)] px-3 py-2 text-slate-200 transition-colors hover:border-violet-400/55 hover:bg-[rgba(168,85,247,0.16)] hover:text-violet-200"
 					on:click={copyMarkdown}
 				>
 					{#if copied}
@@ -157,13 +157,13 @@
 					{/if}
 				</button>
 				<button
-					class="inline-flex items-center gap-2 rounded-xl border border-emerald-400/30 bg-[rgba(8,19,38,0.65)] px-3 py-2 text-slate-200 transition-colors hover:border-emerald-400/55 hover:bg-[rgba(16,185,129,0.16)] hover:text-emerald-200"
+					class="inline-flex items-center gap-2 rounded-xl border border-violet-400/30 bg-[rgba(19,8,48,0.65)] px-3 py-2 text-slate-200 transition-colors hover:border-violet-400/55 hover:bg-[rgba(168,85,247,0.16)] hover:text-violet-200"
 					on:click={() => exportWriteup('markdown')}
 				>
 					<Download size={16} /> Export .md
 				</button>
 				<button
-					class="inline-flex items-center gap-2 rounded-xl border border-sky-400/30 bg-[rgba(8,19,38,0.65)] px-3 py-2 text-slate-200 transition-colors hover:border-sky-400/55 hover:bg-[rgba(56,189,248,0.18)] hover:text-sky-200"
+					class="inline-flex items-center gap-2 rounded-xl border border-indigo-400/30 bg-[rgba(19,8,48,0.65)] px-3 py-2 text-slate-200 transition-colors hover:border-indigo-400/55 hover:bg-[rgba(192,132,252,0.18)] hover:text-indigo-200"
 					on:click={() => exportWriteup('html')}
 				>
 					<Download size={16} /> Export .html
@@ -213,7 +213,7 @@
 				>
 				<h2 class="text-lg font-semibold text-slate-100">Preview</h2>
 				<div
-					class="prose prose-base prose-invert prose-pre:bg-slate-950 prose-pre:text-slate-100 prose-code:text-emerald-400 max-w-none"
+					class="prose prose-base prose-invert prose-pre:bg-slate-950 prose-pre:text-slate-100 prose-code:text-violet-400 max-w-none"
 				>
 					<!-- eslint-disable-next-line svelte/no-at-html-tags -->
 					{@html renderMarkdown(markdownWriteup)}


### PR DESCRIPTION
## Summary
- restyle the global background and shared glass components with a richer violet and fuchsia dark palette
- update navigation, dashboard cards, and writeup surfaces to use the new accent colors and interactions
- align the stats timeline styling with the new theme and exclude large data JSON files from Prettier checks

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e2b257fc34832295c9e31ef0a9f12b